### PR TITLE
[#8] 寝落ちしたユーザーをコマンドで移動させるBotを作成しました 

### DIFF
--- a/python/afk.py
+++ b/python/afk.py
@@ -3,8 +3,13 @@
 from discord.ext import commands
 import discord
 import asyncio
+import setting
 
-TOKEN = 'NzcyMzczMDQ5MzYxMDM5NDEy.X55udA.BAo3aX98kqK6CCEWMCnOqlVy7aw'
+TOKEN           = setting.mToken
+SERVER          = setting.dServer
+VOICE_CHANNEL   = setting.afkChannel
+
+
 bot = commands.Bot(command_prefix="¥",help_command=None)
 
 @bot.event
@@ -22,7 +27,7 @@ async def on_voice_state_update(member, before, after):
 
 @bot.command()
 async def mmv(ctx, mention):
-    server = bot.get_guild(603582455756095488)
+    server = bot.get_guild(SERVER)
     status = ctx.author.voice
     member_id = mention[-19:-1]
     try:
@@ -30,6 +35,9 @@ async def mmv(ctx, mention):
     except:
         await ctx.send("`¥mmv {Mention}`と入力してください。")
     else:
+        print("======")
+        print(member)
+        print("======")
         if status is not None and member.voice is not None:
             channel = status.channel
             mention_channel = member.voice.channel
@@ -38,7 +46,7 @@ async def mmv(ctx, mention):
                     await ctx.send("対象のユーザーがミュートなので実行されませんでした。")
                     return
                 else:
-                    afk_channel = server.get_channel(778975759669788702)
+                    afk_channel = server.get_channel(VOICE_CHANNEL)
                     await member.move_to(afk_channel)
                     await member.edit(mute=True)
                     for channel in server.text_channels:

--- a/python/afk.py
+++ b/python/afk.py
@@ -4,7 +4,7 @@ from discord.ext import commands
 import discord
 import asyncio
 
-TOKEN = ''
+TOKEN = 'NzcyMzczMDQ5MzYxMDM5NDEy.X55udA.BAo3aX98kqK6CCEWMCnOqlVy7aw'
 bot = commands.Bot(command_prefix="¥",help_command=None)
 
 @bot.event
@@ -24,7 +24,7 @@ async def on_voice_state_update(member, before, after):
 async def mmv(ctx, mention):
     server = bot.get_guild(603582455756095488)
     status = ctx.author.voice
-    member_id = mention[3:21]
+    member_id = mention[-19:-1]
     try:
         member = server.get_member(int(member_id))
     except:
@@ -34,20 +34,19 @@ async def mmv(ctx, mention):
             channel = status.channel
             mention_channel = member.voice.channel
             if channel.id == mention_channel.id:
-                if channel.id == 683864874539024397 or channel.id == 603582455756095492 or channel.id == 685652747076632623 or "２人用" in channel.name:
-                        if member.voice.self_mute:
-                            await ctx.send("対象のユーザーがミュートなので実行されませんでした。")
-                            return
-                        else:
-                            afk_channel = server.get_channel(778975759669788702)
-                            await member.move_to(afk_channel)
-                            await member.edit(mute=True)
-                            for channel in server.text_channels:
-                                if channel.topic == str(member_id):
-                                    await channel.send(f"{mention} 寝落ちされていたようなので、ミュート＆移動しました。")
-                                    break
-                            else:
-                                await ctx.send('チャンネルが見つかりませんでした。')
+                if member.voice.self_mute:
+                    await ctx.send("対象のユーザーがミュートなので実行されませんでした。")
+                    return
+                else:
+                    afk_channel = server.get_channel(778975759669788702)
+                    await member.move_to(afk_channel)
+                    await member.edit(mute=True)
+                    for channel in server.text_channels:
+                        if channel.topic == str(member_id):
+                            await channel.send(f"{mention} 寝落ちされていたようなので、ミュート＆移動しました。")
+                            break
+                    else:
+                        await ctx.send('チャンネルが見つかりませんでした。')
             else:
                 await ctx.send("同じvcチャンネルに参加してください。")
         else:

--- a/python/afk.py
+++ b/python/afk.py
@@ -1,0 +1,61 @@
+# -*- coding: utf-8 -*-
+
+from discord.ext import commands
+import discord
+import asyncio
+
+TOKEN = 'NzcyMzczMDQ5MzYxMDM5NDEy.X55udA.dAfCLYnW_AmvSDkGfrZbeEC6peY'
+bot = commands.Bot(command_prefix="¥",help_command=None)
+
+@bot.event
+async def on_ready():
+    print('--------------------')
+    print('起動中...')
+    print('BOT NAME : ' + bot.user.name)
+    print('BOT ID : ' + str(bot.user.id))
+    print('--------------------')
+
+@bot.event
+async def on_voice_state_update(member, before, after):
+    if before.channel is None:
+        await member.edit(mute=False)
+
+@bot.command()
+async def mmv(ctx, mention):
+    server = bot.get_guild(770973096215707648)
+    status = ctx.author.voice
+    member_id = mention[3:21]
+    member = server.get_member(int(member_id))
+    if status is not None and member.voice is not None:
+        channel = status.channel
+        mention_channel = member.voice.channel
+        if channel.id == mention_channel.id:
+            if channel.id == 683864874539024397 or channel.id == 603582455756095492 or channel.id == 685652747076632623 or channel.id == 777803355098710046:
+                try:
+                    member = server.get_member(int(member_id))
+                except:
+                    await ctx.send("`¥mmv {Mention}`と入力してください。")
+                else:
+                    if member.voice.self_mute:
+                        await ctx.send("対象のユーザーがミュートなので実行されませんでした。")
+                        return
+                    else:
+                        afk_channel = ctx.guild.get_channel(770973905312808991)
+                        await member.move_to(afk_channel)
+                        await member.edit(mute=True)
+                        #channel = server.get_channel(778975668934672404)
+                        #await channel.send(f"{mention} 寝落ちされていたようなので、ミュート＆移動しました。")
+    else:
+        await ctx.send("vcに参加してください。")
+
+@bot.command()
+async def m(ctx):
+    await ctx.author.edit(mute=False)
+
+@bot.command()
+async def test(ctx, mention):
+    member_id = mention[3:21]
+    member = ctx.guild.get_member(int(member_id))
+    await ctx.send(member.voice)
+
+bot.run(TOKEN)

--- a/python/afk.py
+++ b/python/afk.py
@@ -4,7 +4,7 @@ from discord.ext import commands
 import discord
 import asyncio
 
-TOKEN = 'NzcyMzczMDQ5MzYxMDM5NDEy.X55udA.dAfCLYnW_AmvSDkGfrZbeEC6peY'
+TOKEN = ''
 bot = commands.Bot(command_prefix="¥",help_command=None)
 
 @bot.event
@@ -22,40 +22,39 @@ async def on_voice_state_update(member, before, after):
 
 @bot.command()
 async def mmv(ctx, mention):
-    server = bot.get_guild(770973096215707648)
+    server = bot.get_guild(603582455756095488)
     status = ctx.author.voice
     member_id = mention[3:21]
-    member = server.get_member(int(member_id))
-    if status is not None and member.voice is not None:
-        channel = status.channel
-        mention_channel = member.voice.channel
-        if channel.id == mention_channel.id:
-            if channel.id == 683864874539024397 or channel.id == 603582455756095492 or channel.id == 685652747076632623 or channel.id == 777803355098710046:
-                try:
-                    member = server.get_member(int(member_id))
-                except:
-                    await ctx.send("`¥mmv {Mention}`と入力してください。")
-                else:
-                    if member.voice.self_mute:
-                        await ctx.send("対象のユーザーがミュートなので実行されませんでした。")
-                        return
-                    else:
-                        afk_channel = ctx.guild.get_channel(770973905312808991)
-                        await member.move_to(afk_channel)
-                        await member.edit(mute=True)
-                        #channel = server.get_channel(778975668934672404)
-                        #await channel.send(f"{mention} 寝落ちされていたようなので、ミュート＆移動しました。")
+    try:
+        member = server.get_member(int(member_id))
+    except:
+        await ctx.send("`¥mmv {Mention}`と入力してください。")
     else:
-        await ctx.send("vcに参加してください。")
+        if status is not None and member.voice is not None:
+            channel = status.channel
+            mention_channel = member.voice.channel
+            if channel.id == mention_channel.id:
+                if channel.id == 683864874539024397 or channel.id == 603582455756095492 or channel.id == 685652747076632623 or "２人用" in channel.name:
+                        if member.voice.self_mute:
+                            await ctx.send("対象のユーザーがミュートなので実行されませんでした。")
+                            return
+                        else:
+                            afk_channel = server.get_channel(778975759669788702)
+                            await member.move_to(afk_channel)
+                            await member.edit(mute=True)
+                            for channel in server.text_channels:
+                                if channel.topic == str(member_id):
+                                    await channel.send(f"{mention} 寝落ちされていたようなので、ミュート＆移動しました。")
+                                    break
+                            else:
+                                await ctx.send('チャンネルが見つかりませんでした。')
+            else:
+                await ctx.send("同じvcチャンネルに参加してください。")
+        else:
+            await ctx.send("vcに参加してください。")
 
 @bot.command()
 async def m(ctx):
     await ctx.author.edit(mute=False)
-
-@bot.command()
-async def test(ctx, mention):
-    member_id = mention[3:21]
-    member = ctx.guild.get_member(int(member_id))
-    await ctx.send(member.voice)
 
 bot.run(TOKEN)

--- a/python/setting.py
+++ b/python/setting.py
@@ -15,8 +15,10 @@ Bot credential
 dToken = os.environ.get("DISCORD_BOT_TOKEN")
 # Cron
 cToken = os.environ.get("CRON_BOT_TOKEN")
-# テスト007
+# テスト用
 tToken = os.environ.get("TEST_BOT_TOKEN")
+# 管理
+mToken = os.environ.get("MANAGER_BOT_TOKEN")
 
 
 """==============================
@@ -34,6 +36,8 @@ sChannel = int(os.environ.get("SLOT_RESULT_CHANNEL_ID"))
 wChannel = int(os.environ.get("WEEK_RECORD_CHANNEL_ID"))
 ## 月間勉強集計
 mChannel = int(os.environ.get("MONTH_RECORD_CHANNEL_ID"))
+## AFK
+afkChannel = int((os.environ.get("AFK_CHANNEL_ID")
 
 # role
 tServer = int(os.environ.get("TEST_SEVER_ID"))


### PR DESCRIPTION
## 条件
- 同じVCチャンネル内にいること
- 寝落ちしたユーザーがミュートしていないこと
- 一人用の勉強机以外で使用すること
## Commands
- ¥mmv {@mention}
メンションされたユーザーはAFKチャンネルに移動され、サーバーミュートされます。
- ¥m
通常、vcに再度参加するとサーバーミュートが外れますが、何かのエラーで解除されない場合はこのコマンドを打つことで解除されます。

## 注意点
- 寝落ちしていないユーザーを、わざとコマンドで移動させるようなことはしないようにお願いします。