### PR TITLE
[#21] vcに入った時にroleを付与/はく奪するコードをjsからpyに移行させました

### DIFF
--- a/python/Cogs/Managements/voiceChannelJoinLeave_roleModify.py
+++ b/python/Cogs/Managements/voiceChannelJoinLeave_roleModify.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+
+from discord.ext import commands
+import discord
+import asyncio
+
+class VoiceJoin_Role(commands.Cog):
+
+    def __init__(self,bot):
+        self.bot = bot
+
+    @commands.Cog.listener()
+    async def on_voice_state_update(self,member, before, after):
+        if after.channel is not None:                         #vcに参加した時
+            if after.channel.id == A:                         #変数Aには作業部屋チャンネルのidを入れて下さい
+                await self.AddRole(member, a, b)              #引数a,bにはmusic_role,作業部屋用チャットRoleのidを入れてください
+            elif after.channel.id == B:                       #変数Bにはラウンジチャンネルのidを入れて下さい
+                await AddRole(member, a, c)                   #引数a,cにはmusic_role,ラウンジ用チャットRoleのidを入れてください
+        if before.channel is not None:
+            if before.channel.id in (A,B):                    #変数A,Bには作業部屋チャンネル,ラウンジチャンネルのidを書いてください
+                await self.RemoveRole(member, a, b, c)        #引数a,b,cにはmusic_role,作業部屋用チャットRole,ラウンジ用チャットRoleのidを書いてください
+
+    async def AddRole(self,member,*args):
+        for role_id in args:
+            role = member.guild.get_role(role_id)
+            await member.add_roles(role)
+
+    async def RemoveRole(self,member,*args):
+        for role_id in args:
+            role = member.guild.get_role(role_id)
+            await member.remove_roles(role)
+
+def setup(bot):
+    return bot.add_cog(VoiceJoin_Role(bot))

--- a/python/management.py
+++ b/python/management.py
@@ -1,0 +1,14 @@
+from discord.ext import commands
+import discord
+import asyncio
+
+intents = discord.Intents.all()
+TOKEN = '' #TOKENを入力してください
+prefix = "/" #お好きなプレフィックス
+
+bot = commands.Bot(command_prefix=prefix,help_command=None,intents=intents)
+
+bot.load_extension("Cogs.default")
+bot.load_extension("Cogs.Managements.voiceChannelJoinLeave_roleModify")
+
+bot.run(TOKEN)


### PR DESCRIPTION
## 主な機能
- 指定したChannelのvcに入ると、指定したRoleを付与する
- また指定したChannelのvcから抜けると、指定したRoleをはく奪します。

## 導入するにあたって
management.pyでは、prefixとtoken
Cogs/Management/voiceChannelJoinLeave_role.py
では、各channelとroleのidを記述してください。

Closes #21 