### PR TITLE
[新規開発] クエスト機能を作成しました

### DIFF
--- a/python/Cogs/Managements/quest.py
+++ b/python/Cogs/Managements/quest.py
@@ -1,0 +1,95 @@
+from discord.ext import commands
+import discord
+import asyncio
+
+class Quest(commands.Cog):
+
+    def __init__(self,bot):
+        self.bot = bot
+        self.channel_id = 771006468216193064 #クエスト提示版のチャンネルid
+        self.check1 = True #titleが入力されるとFalseになる
+        self.user = None #他の方と競合しない様にするため
+        self.Achieved_channel_id = 788847284606861334
+
+    @commands.Cog.listener()
+    async def on_message(self,message):
+        #メッセージ送信者がBotの場合、処理を実行しない
+        if message.author.bot:
+            return
+        #チャンネルがクエスト提示版か確認
+        if message.channel.id == self.channel_id:
+            # self.check1がTrueの場合実行される
+            # titleを取得
+            if self.check1:
+                self.title = message.content
+                self.check1 = False
+                self.send_bot = await message.channel.send("質問内容を入力してください")
+                self.user = message.author
+                await message.delete()
+                return
+
+            #userがtitleを入力したユーザーと同じ場合実行される
+            #内容を取得し、整形したメッセージをEmbedにし送信する
+            if self.user.id == message.author.id:
+                self.content = message.content
+                embed = discord.Embed(title=self.title,description=await self.txt(message.author.name, self.content, "まだいません"))
+                self.embed_message = await message.channel.send(embed=embed)
+                await message.delete()
+                await self.embed_message.add_reaction("✋")
+                await self.init()
+                await self.wait_reaction(message)
+
+
+            #titleとcontentを別のユーザーが入力した場合の処理
+            else:
+                await message.delete()
+                warning_msg = await message.channel.send(f"{self.user.name}さんが現在入力中です。\nお待ちください。")
+                await asyncio.sleep(5)
+                await warning_msg.delete()
+
+    #Embed作成後にリアクションを押した人が受注者欄の名前に反映される
+    async def wait_reaction(self, message):
+        def check(reaction,user):
+            return user.id != self.user.id and reaction.emoji == "✋"
+        reaction, user = await self.bot.wait_for('reaction_add', check=check)
+        embed = discord.Embed(title=self.title, description=await self.txt(message.author.name, self.content, user.name))
+        await self.embed_message.edit(embed=embed)
+
+    #設定を全て初期化する
+    #embedが送信された場合に呼び出される
+    async def init(self):
+        self.check1 = True
+        await self.send_bot.delete()
+
+    #Embedの整形用関数
+    async def txt(self, name, content, contractor):
+        return f"""
+----------------
+依頼人 : {name}
+----------------
+{content}
+----------------
+受注者 : {contractor}
+"""
+
+    @commands.Cog.listener()
+    async def on_raw_reaction_add(self, payload):
+        if payload.channel_id == self.channel_id:
+            guild = payload.member.guild
+            message = await guild.get_channel(payload.channel_id).fetch_message(payload.message_id)
+
+            #titleだけ入力し、内容を書かずに放置されてた場合に、リアクションを押すとresetできる機能
+            if str(payload.emoji) == "🛑":
+                await message.delete()
+                await self.init()
+
+            # 達成したクエストを達成済みクエストチャンネルに移動させる機能
+            if str(payload.emoji) == "✅":
+                Achieved_channel = guild.get_channel(self.Achieved_channel_id)
+                embed_obj = message.embeds[0]
+                embed = discord.Embed(title=embed_obj.title,description=embed_obj.description)
+                await Achieved_channel.send(embed=embed)
+                await message.delete()
+
+def setup(bot):
+    return bot.add_cog(Quest(bot))

--- a/python/management.py
+++ b/python/management.py
@@ -13,5 +13,6 @@ bot = commands.Bot(command_prefix=prefix,help_command=None,intents=intents)
 bot.load_extension("Cogs.default")
 #bot.load_extension("Cogs.Managements.voiceChannelJoinLeave_roleModify")
 bot.load_extension("Cogs.Managements.rolesmanager")
+bot.load_extension("Cogs.Managements.quest")
 
 bot.run(TOKEN)


### PR DESCRIPTION
## 主な機能
mo9mo9サーバーにいる方に質問をクエストという形ですることができるようになります。

## 処理の流れ
1. まずクエスト提示版チャンネルにtitleを入力します
2. すると画像の様に質問内容を入力してくださいと促されます。
![スクリーンショット 2020-12-17 04 54 36](https://user-images.githubusercontent.com/74402807/102400115-cef38c00-4024-11eb-85a9-7e243c784b84.png)
3. 続けて質問内容を入力します。
4. するとこのように整形されたメッセージがEmbedになって送信されます。
![スクリーンショット 2020-12-17 04 54 52](https://user-images.githubusercontent.com/74402807/102400221-f185a500-4024-11eb-9a18-c848420b7201.png)
5. 自分以外のユーザーが:raised_hand: リアクションを押すと、受注者のところに押した人の名前が載ります。
![スクリーンショット 2020-12-17 04 55 01](https://user-images.githubusercontent.com/74402807/102400403-38739a80-4025-11eb-8de7-74c751bde694.png)
6. 問題が解決したら運営の方が:white_check_mark: を押します。
![スクリーンショット 2020-12-17 04 55 07](https://user-images.githubusercontent.com/74402807/102400437-46c1b680-4025-11eb-898d-ec13c232536a.png)
7. すると達成済みクエストチャンネルにメッセージが飛ばされます。
![スクリーンショット 2020-12-17 04 55 43](https://user-images.githubusercontent.com/74402807/102400600-82f51700-4025-11eb-9d84-7714fa847bc2.png)

以上が基本的な処理の流れになります。

## それ以外の処理
- titleを入力した人以外のユーザーがtitleを入力しようとすると、注意文が表示されます。(5秒で自動的に消えます)
![スクリーンショット 2020-12-17 05 08 33](https://user-images.githubusercontent.com/74402807/102401015-ff87f580-4025-11eb-9aed-df5e4141ea94.png)

- titleだけ入力して質問内容を入力していない場合、他の方がずっと書き込めない状態になってしまいます。
- それを解決するために 🛑 このリアクションを押すと処理をリセットすることができます。
![スクリーンショット 2020-12-17 05 07 39](https://user-images.githubusercontent.com/74402807/102400897-d9625580-4025-11eb-9b8c-dcfd80508752.png)

## 導入するにあたって
```
    def __init__(self,bot):
        self.bot = bot
        self.channel_id = 771006468216193064 #クエスト提示版のチャンネルid
        self.check1 = True #titleが入力されるとFalseになる
        self.user = None #他の方と競合しない様にするため
        self.Achieved_channel_id = 788856830583111681
```
この部分のself.channel_idをクエスト提示版チャンネルのidに
self.Achieved_channel_idを達成済みクエスト提示版チャンネルのidに変更してください