### PR TITLE
[#55] 管理者限定コマンドkickを作成しました

### DIFF
--- a/python/Cogs/Managements/memberOrganization.py
+++ b/python/Cogs/Managements/memberOrganization.py
@@ -1,0 +1,131 @@
+from discord.ext import commands
+import discord
+import asyncio
+
+class MemberOrganization(commands.Cog):
+
+    def __init__(self,bot):
+        self.bot = bot
+        self.GUILD_ID = 603582455756095488 #mo9mo9サーバーのid
+        self.target_list = [] #空のlist 変更しないでください
+
+    #Bot起動時にguildを読み込む
+    @commands.Cog.listener()
+    async def on_ready(self):
+        self.GUILD = self.bot.get_guild(self.GUILD_ID)
+
+    @commands.command()
+    async def kick(self, ctx, subcommand, id=None):
+        #管理者のみ実行可能
+        if not ctx.author.guild_permissions.administrator:
+            return
+
+        #---対象者をtarget_listに追加する処理---
+        if subcommand == "add":
+            #userを取得し、成功したらTrueとdiscord.Memberオブジェクトが帰ってくる
+            #エラーが出ると、FalseとNoneが帰ってくる
+            bool,user = await self.get_user(ctx, id)
+            #Trueだった場合
+            if bool:
+                #既にtarget_listにuserが入っているか確認
+                if user in self.target_list:
+                    #入っていた場合はlistに追加しない
+                    await ctx.send(f"{user.name}は既にlistに入っています。")
+                    return
+                #listに追加し、今追加したユーザーの名前と現在のlistに追加されている人数を表示
+                self.target_list.append(user)
+                count = len(self.target_list)
+                await ctx.send(f"{user.name}をlistに追加しました。現在{str(count)}人")
+
+        #---対象者をtarget_listから取り消す処理---
+        elif subcommand == "remove":
+            #userを取得し、成功したらTrueとdiscord.Memberオブジェクトが帰ってくる
+            #エラーが出ると、FalseとNoneが帰ってくる
+            bool, user = await self.get_user(ctx, id)
+            #Trueだった場合
+            if bool:
+                #target_listにuserが入っているか確認
+                if user not in self.target_list:
+                    #入ってない場合はエラー文を出す
+                    await ctx.send(f"{user.name}はlistに入ってないため、取り消せませんでした。")
+                    return
+                #listから取り消し、今取り消したユーザーの名前と現在のlistに追加されている人数を表示
+                self.target_list = [t for t in self.target_list if t != user]
+                count = len(self.target_list)
+                await ctx.send(f"{user.name}をlistから取り消しました。現在{str(count)}人")
+
+        #---対象者一覧を表示する処理---
+        elif subcommand == "targets":
+            #target_listの中身をdiscord.Memberオブジェクトからnameオブジェクトに変更
+            display_list = list(map(lambda t:t.name, self.target_list))
+            #要素ごとに改行を挟む
+            display_list = "\n".join(display_list)
+            #現在のlistに追加されている人数とlist内の人全員を表示
+            count = len(display_list)
+            await ctx.send(f"現在{str(count)}人がlistに入っています。\n{display_list}")
+
+        #---対象者に処理を実行するコマンド---
+        elif subcommand == "run":
+            await ctx.send("処理を開始します。")
+            for member in self.target_list:
+                #自動メッセージを対象者のDMに送る
+                dm = await member.create_dm()
+                await dm.send(txt)
+                #対象者のtimesを削除
+                for channel in self.GUILD.text_channels:
+                    if channel.topic == str(member.id):
+                        await channel.delete()
+                        break
+                #メンバーをキック
+                await member.kick()
+
+        #---対象者listをリセットする---
+        elif subcommand == "reset":
+            self.target_list = []
+            await ctx.send("対象者listをリセットしました")
+
+
+
+    #---kickコマンド内の[add/remove]処理でのみ呼び出されます---
+    async def get_user(self, ctx, id):
+        # idがNoneの時(引数に何も入ってない時)、idを入れるよう促す
+        if id == None:
+            await ctx.send("第二引数に対象者のidを入れてください。")
+            return False, None
+        # 引数idに数字以外を入れてしまって、intに変換した時にエラーが出るのを防ぐための例外処理
+        try:
+            # 引数idからdiscord.Memberオブジェクトを取得
+            user = self.GUILD.get_member(int(id))
+        # valueErrorが出たときに警告文を表示
+        except ValueError:
+            await ctx.send("第二引数には数字のみを入れて下さい。")
+        # discord.Memberオブジェクトを正常に取得できた時の処理
+        else:
+            # userが取得出来なかった時にエラー文を出す
+            if user is None:
+                await ctx.send("userが見つかりませんでした。\nidが間違ってないか確認してください。")
+                return False, None
+            return True , user
+
+txt = """
+当ギルド[ もくもくOnline勉強会 ]で
+以下の整理対象条件のいずれかを満たしたためギルドメンバーから削除致しました。
+- 学びの活動(勉強記録)が２ヶ月以上確認できない
+- 初参加から一定の活動がみられない
+
+このメッセージに気付き、
+また、この学び続ける仲間が居るコミュニティを活用し、
+メンバー同士刺激しつつ「やる気」を維持していきたいと
+思われた時は下記のTwitterかbopsyuまで連絡下さい
+
+改めて招待URLを発行し、仲間一同参加を快く歓迎します
+※ギルドの質担保のための行動へのご理解よろしくお願い致します。
+
+・もくもくOnline勉強会専用Twitterアカウント
+  	@mo9mo9study
+・bosyuのギルドメンバー募集ページ
+  	https://bosyu.me/b/G43e6INUpQw
+"""
+
+def setup(bot):
+    return bot.add_cog(MemberOrganization(bot))

--- a/python/management.py
+++ b/python/management.py
@@ -20,5 +20,6 @@ bot.load_extension("Cogs.Managements.VCinvite")
 bot.load_extension("Cogs.Managements.view_TimesChannel")
 bot.load_extension("Cogs.afk.afk")
 bot.load_extension("Cogs.afk.unmute")
+bot.load_extension("Cogs.Managements.memberOrganization")
 
 bot.run(TOKEN)


### PR DESCRIPTION
## 機能説明
- メンバー整理の自動化
管理者が手動でメッセージを送り、kickしていた作業を自動化できます。
管理者のみ使えます。

## メインコマンド [kick]
コマンドの構文
- ¥kick [SubCommands] [options]

## SubCommand一覧
- add {member_id}
member_idに指定したユーザーを対象者listに追加します。
(このリストの中に入っている人がkickされます。)

- remove {member_id}
addで追加したユーザーを対象者listから取り消します。
(間違ってリストに入れてしまった場合にご活用ください)

- targets
対象者listを表示することができます。
(¥runコマンドを実行する前にこのコマンドでご確認ください。)

- run
対象者listに入っているメンバーに対して、`処理の流れ`に書いてある処理を行います
(このコマンドが実行されると、対象者のtimesが消えたりkickされたりするので気を付けて使用してください。)

- reset
対象者listをリセット(初期の状態に)することができます。
 
## 処理の流れ
対象者をリストに追加し、runコマンド実行後を前提とします。
1. 対象者リストにいるメンバー全員に定型文が自動送信されます。
2. 対象者リストに入っているメンバーのtimes_channelが自動削除されます。
3. 対象者がGuildからKickされます。

## 導入にあたって
def __init__(self, bot):
の中にある
self.GUILD_IDの値をmo9mo9サーバーのidに変更してください

対象者に送られるメッセージを変更する場合は、MemberOrganization.pyの一番下にあるtxt変数の中身から出来ます。