### PR TITLE
[#126] DM間で発生するreaction_addでmemberオブジェクトを取得できない問題を解決

### DIFF
--- a/Cogs/Managements/rolesmanager.py
+++ b/Cogs/Managements/rolesmanager.py
@@ -1,31 +1,43 @@
+import asyncio
+
 from discord.ext import commands
 import discord
-import asyncio
-from .voiceChannelJoinLeave_roleModify import VoiceJoin_Role
 import yaml
+
+from .voiceChannelJoinLeave_roleModify import VoiceJoin_Role
+
 
 class Reaction_AddRole(VoiceJoin_Role):
 
-    def __init__(self,bot):
+    def __init__(self, bot):
         self.bot = bot
         self.guild_id = 603582455756095488
         self.channel_id = 704579339173494835
 
     @commands.Cog.listener()
     async def on_ready(self):
-        with open('Settings/role.yaml',encoding="utf-8") as file:
+        with open('Settings/role.yaml', encoding="utf-8") as file:
             self.role = yaml.safe_load(file.read())
 
-        self.channel = self.bot.get_guild(self.guild_id).get_channel(self.channel_id)
+        self.channel = self.bot.get_guild(
+            self.guild_id).get_channel(self.channel_id)
         await self.channel.purge()
 
-        role_name = map(lambda role_obj: role_obj["role_name"], self.role["roles"])
-        role_reaction = map(lambda role_obj: role_obj["reaction"], self.role["roles"])
-        desc = "\n".join(a + " : #" + b for a, b in zip(role_reaction, role_name))
-        embed = discord.Embed(title="対応した役職を付与します", description=desc + "\n(※ 🗑️ : 自動で付与/剥奪できる役職全てを剥奪します )")
+        role_name = map(
+            lambda role_obj: role_obj["role_name"], self.role["roles"])
+        role_reaction = map(
+            lambda role_obj: role_obj["reaction"], self.role["roles"])
+        desc = "\n".join(a + " : #" + b for a,
+                         b in zip(role_reaction, role_name))
+        embed = discord.Embed(
+            title="対応した役職を付与します",
+            description=desc + "\n(※ 🗑️ : 自動で付与/剥奪できる役職全てを剥奪します )")  # noqa : E501
         for roles in self.role["roles"]:
             values = '\n- #'.join(roles['subChannel_name'])
-            embed.add_field(name=f"[{roles['reaction']} : {roles['role_name']}]", value=f"- #{values}", inline=True)
+            embed.add_field(
+                name=f"[{roles['reaction']} : {roles['role_name']}]",
+                value=f"- #{values}",
+                inline=True)
         self.message = await self.channel.send(embed=embed)
         self.message_id = self.message.id
 
@@ -33,31 +45,42 @@ class Reaction_AddRole(VoiceJoin_Role):
             await self.message.add_reaction(roles["reaction"])
 
     @commands.Cog.listener()
-    async def on_raw_reaction_add(self,payload):
-        if payload.member.bot:
+    async def on_raw_reaction_add(self, payload):
+        # BOTとのDMのリアクションの場合payload.memberの値がNoneになってしまうため
+        # reaction_remove同様にreaction_addでもfetch_userでmenberオブジェクトを取得する
+        member = await self.bot.fetch_user(payload.user_id)
+        if member.bot:
             return
         if payload.message_id == self.message_id:
             await self.wastebasket(payload, self.channel)
             for roles in self.role["roles"]:
-                await self.Add_Reaction(payload, roles["reaction"], roles["roles_id"])
-            await self.send_message("add",payload,payload.member,self.channel)
+                await self.Add_Reaction(payload,
+                                        roles["reaction"],
+                                        roles["roles_id"])
+            await self.send_message("add", payload, member, self.channel)
 
     @commands.Cog.listener()
-    async def on_raw_reaction_remove(self,payload):
+    async def on_raw_reaction_remove(self, payload):
         guild = self.bot.get_guild(payload.guild_id)
-        member = guild.get_member(payload.user_id)
+        member = await self.bot.fetch_user(payload.user_id)
         if member.bot:
             return
         if payload.message_id == self.message_id:
-            message = await guild.get_channel(self.channel_id).fetch_message(self.message_id)
+            message = await guild.get_channel(self.channel_id).fetch_message(self.message_id)  # noqa : E501
             reactions = message.reactions
             for reaction in reactions:
                 if str(reaction) == "🗑️":
                     break
             else:
                 for roles in self.role["roles"]:
-                    await self.Remove_Reaction(payload, member, roles["reaction"], roles["roles_id"])
-                await self.send_message("remove",payload,member,self.channel)
+                    await self.Remove_Reaction(payload,
+                                               member,
+                                               roles["reaction"],
+                                               roles["roles_id"])
+                await self.send_message("remove",
+                                        payload,
+                                        member,
+                                        self.channel)
 
     async def Add_Reaction(self, payload, reaction, *args):
         if str(payload.emoji) == reaction:
@@ -76,22 +99,25 @@ class Reaction_AddRole(VoiceJoin_Role):
             text2 = "をはく奪しました"
         for roles in self.role["roles"]:
             if str(payload.emoji) == roles["reaction"]:
-                msg = await channel.send(f"{member.name}{text1}役職[ {roles['role_name']} ]{text2}")
+                msg = await channel.send(f"{member.name}{text1}役職[ {roles['role_name']} ]{text2}")  # noqa : E501
                 await self.time_sleep(5, msg)
 
-    async def time_sleep(self,second,msg):
+    async def time_sleep(self, second, msg):
         await asyncio.sleep(second)
         await msg.delete()
 
-    async def wastebasket(self,payload ,channel):
+    async def wastebasket(self, payload, channel):
         if str(payload.emoji) == "🗑️":
             for roles in self.role["roles"]:
-                await self.Remove_Reaction(payload, payload.member, "🗑️", roles["roles_id"])
-                await self.message.remove_reaction(roles["reaction"], payload.member)
+                await self.Remove_Reaction(payload,
+                                           payload.member,
+                                           "🗑️",
+                                           roles["roles_id"])
+                await self.message.remove_reaction(roles["reaction"],
+                                                   payload.member)
             msg = await channel.send("全てのロールをはく奪しました")
             await self.message.remove_reaction("🗑️", payload.member)
             await self.time_sleep(5, msg)
-
 
 
 def setup(bot):

--- a/Cogs/Managements/times.py
+++ b/Cogs/Managements/times.py
@@ -89,10 +89,13 @@ class Times(commands.Cog):
 
     @commands.Cog.listener()
     async def on_raw_reaction_add(self, payload):
-        if payload.member.bot:
+        # BOTとのDMのリアクションの場合payload.memberの値がNoneになってしまうため
+        # reaction_remove同様にreaction_addでもfetch_userでmenberオブジェクトを取得する
+        member = await self.bot.fetch_user(payload.user_id)
+        if member.bot:
             return
         if payload.message_id == self.message_id:
-            user_id = int(payload.member.id)
+            user_id = int(member.id)
             for channel in self.GUILD.text_channels:
                 if channel.topic == str(user_id):
                     msg = await self.TIMES_CREATE.send(textwrap.dedent(f"""\
@@ -100,7 +103,7 @@ class Times(commands.Cog):
                         {self.VIEW_TIMES.mention} でtimesに移動しよう"""))
                     await self.time_sleep(msg)
                     await self.message.remove_reaction(payload.emoji,
-                                                       payload.member)
+                                                       member)
                     break
             else:
                 await self.channelCreateSend(self.getMember(user_id))
@@ -109,7 +112,7 @@ class Times(commands.Cog):
                     {self.VIEW_TIMES.mention} でtimesに移動しよう"""))
                 await self.time_sleep(msg)
                 await self.message.remove_reaction(payload.emoji,
-                                                   payload.member)
+                                                   member)
 
     async def time_sleep(self, msg):
         await asyncio.sleep(self.second)


### PR DESCRIPTION
- payload.memberが取得できない条件
  - DMでのリアクションイベント（add/remove)
  - テキストチャットのremoveリアクションイベント
- addもremove同様にbot.fetch_userでmemberオブジェクトを取得するようにしました