### PR TITLE
Supleiades/20210921/fix #128 voicejoin break connection

### DIFF
--- a/Cogs/Managements/rolesmanager.py
+++ b/Cogs/Managements/rolesmanager.py
@@ -7,7 +7,7 @@ import yaml
 from .voiceChannelJoinLeave_roleModify import VoiceJoin_Role
 
 
-class Reaction_AddRole(VoiceJoin_Role):
+class Reaction_AddRole(commands.Cog):
 
     def __init__(self, bot):
         self.bot = bot
@@ -84,11 +84,11 @@ class Reaction_AddRole(VoiceJoin_Role):
 
     async def Add_Reaction(self, payload, reaction, *args):
         if str(payload.emoji) == reaction:
-            await self.AddRole(payload.member, *args)
+            await VoiceJoin_Role(self.bot).AddRole(payload.member, *args)
 
     async def Remove_Reaction(self, payload, member, reaction, *args):
         if str(payload.emoji) == reaction:
-            await self.RemoveRole(member, *args)
+            await VoiceJoin_Role(self.bot).RemoveRole(member, *args)
 
     async def send_message(self, mode, payload, member, channel):
         if mode == "add":

--- a/Cogs/Managements/voiceChannelJoinLeave_roleModify.py
+++ b/Cogs/Managements/voiceChannelJoinLeave_roleModify.py
@@ -25,11 +25,13 @@ class VoiceJoin_Role(commands.Cog):
                 if after.channel.id == self.workRoomVoiceChatId:
                     print(f"[INFO] {member.name}が{after.channel.name}に入室")
                     await self.AddRole(member,
+                                       self.GUILD,
                                        self.musicChatRoleId,
                                        self.workRoomChatRoleId)
                 elif after.channel.id == self.loungeVoiceChatId:
                     print(f"[INFO] {member.name}が{after.channel.name}に入室")
                     await self.AddRole(member,
+                                       self.GUILD,
                                        self.musicChatRoleId,
                                        self.loungeChatRoleId)
             if before.channel is not None:  # 対象VC退室時
@@ -37,19 +39,20 @@ class VoiceJoin_Role(commands.Cog):
                                          self.loungeVoiceChatId):
                     print(f"[INFO] {member.name}が{before.channel.name}から退室")
                     await self.RemoveRole(member,
+                                          self.GUILD,
                                           self.musicChatRoleId,
                                           self.workRoomChatRoleId,
                                           self.loungeChatRoleId)
 
-    async def AddRole(self, member, *args):
+    async def AddRole(self, member, guild, *args):
         for role_id in args:
-            role = self.GUILD.get_role(role_id)
+            role = guild.get_role(role_id)
             print(f"[INFO] {member.name}に権限「{role.name}」を付与")
             await member.add_roles(role)
 
-    async def RemoveRole(self, member, *args):
+    async def RemoveRole(self, member, guild, *args):
         for role_id in args:
-            role = self.GUILD.get_role(role_id)
+            role = guild.get_role(role_id)
             print(f"[INFO] {member.name}から権限「{role.name}」を剥奪")
             await member.remove_roles(role)
 

--- a/Cogs/Managements/voiceChannelJoinLeave_roleModify.py
+++ b/Cogs/Managements/voiceChannelJoinLeave_roleModify.py
@@ -10,7 +10,7 @@ class VoiceJoin_Role(commands.Cog):
         self.GUILD_ID = 603582455756095488
         self.workRoomChatRoleId = 763401369784156211  # 「作業部屋用チャット」表示権限ID
         self.loungeChatRoleId = 763400537257148446  # 「ラウンジ用チャット」表示権限ID
-        self.musicChatRokeId = 710333297598922752  # 「musicbot操作用」表示権限ID
+        self.musicChatRoleId = 710333297598922752  # 「musicbot操作用」表示権限ID
         self.workRoomVoiceChatId = 683864874539024397  # 「作業部屋」ID
         self.loungeVoiceChatId = 603582455756095492  # 「ラウンジ」ID
 
@@ -25,19 +25,19 @@ class VoiceJoin_Role(commands.Cog):
                 if after.channel.id == self.workRoomVoiceChatId:
                     print(f"[INFO] {member.name}が{after.channel.name}に入室")
                     await self.AddRole(member,
-                                       self.musicChatRokeId,
+                                       self.musicChatRoleId,
                                        self.workRoomChatRoleId)
                 elif after.channel.id == self.loungeVoiceChatId:
                     print(f"[INFO] {member.name}が{after.channel.name}に入室")
                     await self.AddRole(member,
-                                       self.musicChatRokeId,
+                                       self.musicChatRoleId,
                                        self.loungeChatRoleId)
             if before.channel is not None:  # 対象VC退室時
                 if before.channel.id in (self.workRoomVoiceChatId,
                                          self.loungeVoiceChatId):
                     print(f"[INFO] {member.name}が{before.channel.name}から退室")
                     await self.RemoveRole(member,
-                                          self.musicChatRokeId,
+                                          self.musicChatRoleId,
                                           self.workRoomChatRoleId,
                                           self.loungeChatRoleId)
 

--- a/Cogs/Managements/voiceChannelJoinLeave_roleModify.py
+++ b/Cogs/Managements/voiceChannelJoinLeave_roleModify.py
@@ -7,11 +7,16 @@ class VoiceJoin_Role(commands.Cog):
 
     def __init__(self, bot):
         self.bot = bot
+        self.GUILD_ID = 603582455756095488
         self.workRoomChatRoleId = 763401369784156211  # 「作業部屋用チャット」表示権限ID
         self.loungeChatRoleId = 763400537257148446  # 「ラウンジ用チャット」表示権限ID
         self.musicChatRokeId = 710333297598922752  # 「musicbot操作用」表示権限ID
         self.workRoomVoiceChatId = 683864874539024397  # 「作業部屋」ID
         self.loungeVoiceChatId = 603582455756095492  # 「ラウンジ」ID
+
+    @commands.Cog.listener()
+    async def on_ready(self):
+        self.GUILD = self.bot.get_guild(self.GUILD_ID)
 
     @commands.Cog.listener()
     async def on_voice_state_update(self, member, before, after):
@@ -38,13 +43,13 @@ class VoiceJoin_Role(commands.Cog):
 
     async def AddRole(self, member, *args):
         for role_id in args:
-            role = member.guild.get_role(role_id)
+            role = self.GUILD.get_role(role_id)
             print(f"[INFO] {member.name}に権限「{role.name}」を付与")
             await member.add_roles(role)
 
     async def RemoveRole(self, member, *args):
         for role_id in args:
-            role = member.guild.get_role(role_id)
+            role = self.GUILD.get_role(role_id)
             print(f"[INFO] {member.name}から権限「{role.name}」を剥奪")
             await member.remove_roles(role)
 


### PR DESCRIPTION
issue: #128
- rolemanagerのクラスが他ファイルのクラスを読んでいた繋がりをcommands.Cogに変更
- on_readyでギルドオブジェクトを呼ぶように修正
- fetch_userではadd_roleのメソッドがないためfetch_memberに変更
- ロール付与の関数の引数にギルドオブジェクトを指定するよう追加
- 変数のタイポを修正