### PR TITLE
[#151]3ヶ月未使用のtimesを削除する処理が定期実行されていない問題を解決

### DIFF
--- a/Cogs/Managements/regularly_times_delete.py
+++ b/Cogs/Managements/regularly_times_delete.py
@@ -17,6 +17,7 @@ class RegularlyTimesDelete(commands.Cog):
     async def on_ready(self):
         self.GUILD = self.bot.get_guild(self.GUILD_ID)
         self.LOG_CHANNEL = self.GUILD.get_channel(self.LOG_CHANNEL_ID)
+        self.regularly_times_delete.start()
 
     async def times_delete(self):
         deletetimes_count = 0


### PR DESCRIPTION
- on_ready内にtasks.loopの.start()のトリガーを追記
issue: #151 