### PR TITLE
Supleiades/20211107/fix 124 db version of selfintroduction

### DIFF
--- a/Cogs/Managements/selfIntroduction.py
+++ b/Cogs/Managements/selfIntroduction.py
@@ -109,7 +109,7 @@ class Self_Introduction(commands.Cog):
         """
         # session = Selfintroduction.session()
         obj = self.db_select_selfintroduction(session, member)
-        reset_columns = ["nickname", "sex", "twitter_id", "specialty",
+        reset_columns = ["nickname", "gender", "twitter_id", "specialty",
                          "before_study", "after_study"]
         for column in reset_columns:
             setattr(obj, column, None)
@@ -168,8 +168,8 @@ class Self_Introduction(commands.Cog):
         # 次修正するカラムを確認
         if not m_d.nickname and m_d.mod_column != "nickname":
             next_missingdata_column = "nickname"
-        elif not m_d.sex and m_d.mod_column != "sex":
-            next_missingdata_column = "sex"
+        elif not m_d.gender and m_d.mod_column != "gender":
+            next_missingdata_column = "gender"
         elif not m_d.twitter_id and m_d.mod_column != "twitter_id":
             next_missingdata_column = "twitter_id"
         elif not m_d.specialty and m_d.mod_column != "specialty":
@@ -207,7 +207,7 @@ class Self_Introduction(commands.Cog):
         """
         if next_missingdata_column == "nickname":
             next_msg = self.question1
-        elif next_missingdata_column == "sex":
+        elif next_missingdata_column == "gender":
             next_msg = f"""\> 性別を教えて下さい。\n{self.question2}"""  # noqa: W605
         elif next_missingdata_column == "twitter_id":
             next_msg = self.question3
@@ -242,7 +242,7 @@ class Self_Introduction(commands.Cog):
             await dm.send(embed=self.strfembed(send_msg))
             check_msg = False
         else:
-            if missingdata_column == "sex":
+            if missingdata_column == "gender":
                 if msg_cont not in ["男", "女", "非公開"]:
                     check_msg = False
         return check_msg
@@ -371,7 +371,7 @@ class Self_Introduction(commands.Cog):
         embed = discord.Embed(
             title="自己紹介",
             description=desc_msg,  # noqa: E501
-            color=self.gender_color(obj.sex))
+            color=self.gender_color(obj.gender))
         embed.set_thumbnail(url=member.avatar_url)
         embed.add_field(name="【 __呼び名__ 】",
                         value=f":name_badge: {obj.nickname}",
@@ -444,10 +444,10 @@ class Self_Introduction(commands.Cog):
         embed = discord.Embed(
             title="現在自己紹介を修正",
             description=desc,
-            color=self.gender_color(obj.sex))
+            color=self.gender_color(obj.gender))
         embed.add_field(name=f"{number[0]}",
                         value=obj.nickname, inline=False)
-        embed.add_field(name=f"{number[1]}", value=obj.sex, inline=False)
+        embed.add_field(name=f"{number[1]}", value=obj.gender, inline=False)
         embed.add_field(name=f"{number[2]}",
                         value=obj.twitter_id, inline=False)
         embed.add_field(name=f"{number[3]}",
@@ -469,7 +469,7 @@ class Self_Introduction(commands.Cog):
             if emoji == "1⃣":
                 select_column = "nickname"
             elif emoji == "2⃣":
-                select_column = "sex"
+                select_column = "gender"
             elif emoji == "3⃣":
                 select_column = "twitter_id"
             elif emoji == "4⃣":

--- a/Cogs/Managements/selfIntroduction.py
+++ b/Cogs/Managements/selfIntroduction.py
@@ -1,6 +1,8 @@
 import discord
 from discord.ext import commands
 
+from mo9mo9db.dbtables import Selfintroduction
+
 
 class Self_Introduction(commands.Cog):
 
@@ -38,14 +40,20 @@ class Self_Introduction(commands.Cog):
                     return
                 await self.complete(channel, member.id)
 
-    # サーバーにメンバーが参加した時
+    async def db_insert_selfintroduction(self, member):
+        obj = Selfintroduction(
+            guild_id=member.guild.id,
+            member_id=member.id
+        )
+        Selfintroduction.insert(obj)
 
+    # サーバーにメンバーが参加した時
     @commands.Cog.listener()
     async def on_member_join(self, member):
         # discord.DMChannelオブジェクトを取得
         dm = await member.create_dm()
-        # 参加したメンバーのidを名前にしたTextChannelを作成
-        await self.DEBUG_GUILD.create_text_channel(str(member.id))
+        # selfintroductionテーブルに参加したメンバーの情報をinsert
+        await self.db_insert_selfintroduction(member)
         # 参加者にdmを送る
         await dm.send(embed=self.strfembed("""\
 ギルドへの参加ありがとうございます

--- a/Cogs/Managements/selfIntroduction.py
+++ b/Cogs/Managements/selfIntroduction.py
@@ -234,7 +234,6 @@ class Self_Introduction(commands.Cog):
                                                  message.content)
         if check_msg:
             return
-        # 後ほど
         # 不足しているデータをDBに書き込み
         self.db_update_selfintroduction(member, missingdata_column,
                                         message.content,
@@ -242,8 +241,8 @@ class Self_Introduction(commands.Cog):
         # 不足しているデータから次の送信メッセージを選択
         send_msg = self.select_nextquestionmsg(next_missingdata_column)
         await dm.send(embed=self.strfembed(send_msg))
-        # データに不足がない場合
         if not missingdata_column and not next_missingdata_column:
+            # データに不足がない場合
             comp_msg = f"{message.author.name}さんの自己紹介文は既に登録済みです。"\
                 + "\n変更する場合は、[ ¥predit ]とコマンドを送信して下さい。"
             await message.channel.send(embed=self.strfembed(comp_msg))
@@ -251,10 +250,57 @@ class Self_Introduction(commands.Cog):
         # メッセージを勉強ギルドに送信する処理
         # ここ続けて書く必要あり
 
-    # ---on_messageイベント内でのみ呼び出される---
-    # channelとdmにメッセージを送信するメソッド
+    async def send_selfintroduction(self, member) -> None:
+        """
+        DBに補完された自己紹介データをEmbedの形に入れ込み、自己紹介を送信する
+
+        Parameter
+        ---------
+        member : discord.Member
+            message.authorから取得したメンバーオブジェクト
+        """
+        dm = await member.create_dm()
+        embed = self.add_embed(member)
+        # 完成した自己紹介文の最終チェック(修正が可能)
+        embed_message = await dm.send(embed=embed)
+        send_msg = "この内容で自己紹介を登録しますか？"\
+            + "OKなら👍リアクションを、修正する場合は♻️リアクションを押して下さい。"\
+            + "部分的に修正する場合は一度👍リアクションを押して投稿した後に修正可能になります"  # noqa: E501
+        await dm.send(embed=self.strfembed(send_msg))
+        # リアクションを追加
+        await embed_message.add_reaction("👍")
+        await embed_message.add_reaction("♻️")
+        # 押されたemojiを取得
+        emoji = await self.wait_reaction_add(embed_message, ["👍", "♻️"])
+        # 押された絵文字が👍の時(今の内容で登録する)
+        if emoji == "👍":
+            after_msg = await self.INTRODUCTION_CHANNEL.send(embed=embed)
+            await after_msg.add_reaction("<:yoroshiku:761730298106478592>")
+            # DBの自己紹介メッセージIDを送信後のメッセージIDに変更
+            await self.db_update_selfintroduction(member, "sendmsg_id",
+                                                  after_msg.id, None)
+            send_msg2 = "登録が完了しました" \
+                + "※登録した自己紹介を修正したい場合は[ ¥predit ]とコマンドを送信してください"   # noqa: E501
+            await dm.send(embed=self.strfembed(send_msg2))
+        elif emoji == "♻️":
+            await self.selfintroduction_reset(dm)
+
+    async def selfintroduction_msg_update(self, member):
+        member_data = self.db_select_selfintroduction(member)
+        channel = self.INTRODUCTION_CHANNEL
+        msg_id = member_data["sendmsg_id"]
+        if msg_id:
+            # 既存の自己紹介メッセージを削除
+            selfintroduction_msg = await channel.fetch_message(msg_id)
+            await selfintroduction_msg.delete()
+        # 完成した自己紹介を送信
+        await self.send_selfintroduction(member)
 
     async def send_message(self, channel, dm, msgcontent, content):
+        """
+        ---on_messageイベント内でのみ呼び出される---
+        channelとdmにメッセージを送信するメソッド
+        """
         await channel.send(msgcontent)
         await dm.send(embed=self.strfembed(content))
 
@@ -271,9 +317,8 @@ class Self_Introduction(commands.Cog):
         # dmオブジェクト作成
         dm = await member.create_dm()
         # 格納されたメッセージをすべて取得
-        messages = await channel.history(limit=None).flatten()
         # embedにして整形
-        embed = self.add_embed(self.adjust(messages), member)
+        embed = self.add_embed(member)
         # 完成した自己紹介文の最終チェック(修正が可能)
         embed_message = await dm.send(embed=embed)
         await dm.send(embed=self.strfembed("""\
@@ -291,11 +336,11 @@ OKなら👍リアクションを、修正する場合は♻️リアクショ�
             register_msg = await self.INTRODUCTION_CHANNEL.send(embed=embed)
             await register_msg.add_reaction("<:yoroshiku:761730298106478592>")
             await channel.send(register_msg.id)
-            await dm.send(embed=self.strfembed("""\
-登録が完了しました
-※登録した自己紹介を修正したい場合は[ ¥predit ]とコマンドを送信してください"""))
+            send_msg2 = "登録が完了しました" \
+                + "※登録した自己紹介を修正したい場合は[ ¥predit ]とコマンドを送信してください"  # noqa: E501
+            await dm.send(embed=self.strfembed(send_msg2))
         elif emoji == "♻️":
-            await self.selfintroduction_reset(channel, dm)
+            await self.selfintroduction_reset(dm)
 
     # 自己紹介を初期化する処理
     async def selfintroduction_reset(self, dm) -> None:
@@ -336,28 +381,27 @@ OKなら👍リアクションを、修正する場合は♻️リアクショ�
         return embed
 
     # 質問内容を追加する場合は、ここを弄る
-    def add_embed(self, list, member):
+    def add_embed(self, member):
+        obj = self.db_select_selfintroduction(member)
         embed = discord.Embed(
             title="自己紹介",
-            description=f"""\
-name: {member.name}
-joined: {str(member.joined_at.strftime('%Y-%m-%d'))}""",
-            color=self.gender_color(list[1]))
+            description=f"name: {member.name}\njoined: {str(member.joined_at.strftime('%Y-%m-%d'))}",  # noqa: E501
+            color=self.gender_color(obj['sex']))
         embed.set_thumbnail(url=member.avatar_url)
         embed.add_field(name="【 __呼び名__ 】",
-                        value=f":name_badge: {list[0]}",
+                        value=f":name_badge: {obj['nickname']}",
                         inline=False)
         embed.add_field(name="【 __TwitterID__ 】",
-                        value=f":globe_with_meridians: @{list[2]}",
+                        value=f":globe_with_meridians: @{obj['twitter_id']}",
                         inline=False)
         embed.add_field(name="【 __得意分野__ 】",
-                        value=f":ideograph_advantage: {list[3]}",
+                        value=f":ideograph_advantage: {obj['specialty']}",
                         inline=False)
         embed.add_field(name="【 __今まで勉強してきたこと__ 】",
-                        value=f":books: {list[4]}",
+                        value=f":books: {obj['before_study']}",
                         inline=False)
         embed.add_field(name="【 __これから勉強していきたいこと__ 】",
-                        value=f":pencil: {list[5]}",
+                        value=f":pencil: {obj['after_study']}",
                         inline=False)
         embed.set_footer(text=f"{member.id}")
         return embed
@@ -384,13 +428,22 @@ joined: {str(member.joined_at.strftime('%Y-%m-%d'))}""",
 
     # ---completeメソッド内でのみ呼び出される---
     # リアクションが押されたら、そのリアクションをreturnする
-    async def wait_reaction_add(self, channel, message, emojis):
-        # リアクションを押したユーザーがbotじゃなく、
-        # 押された絵文字がemojisに格納されている絵文字あり、
-        # リアクションを押したメッセージのidが送信されたembedメッセージのidと同じで、
-        # リアクションを押したユーザーのidとDEBUGサーバー内のchannel名が一致した場合のみ、処理が走る
+    async def wait_reaction_add(self, message, emojis):
+        """
+        リアクションを押したユーザーがbotじゃなく、
+        押された絵文字がemojisに格納されている絵文字あり、
+        リアクションを押したメッセージのidが送信されたembedメッセージのidと同じで、
+        リアクションを押したユーザーのidとDEBUGサーバー内のchannel名が一致した場合のみ、処理が走る
+
+        Parameter
+        ---------
+        message : discord.Message
+            自己紹介完成後の送信前の確認用のembedメッセージオブジェクト
+        emojis : list
+            確認用のembedメッセージに付与されて処理を通す絵文字の一覧
+        """
         def check(reaction, user):
-            return user.bot is False and reaction.emoji in emojis and reaction.message.id == message.id and str(user.id) == channel.name  # noqa: E501
+            return user.bot is False and reaction.emoji in emojis and reaction.message.id == message.id  # noqa: E501
         reaction, user = await self.bot.wait_for('reaction_add', check=check)
         # リアクションが押されたら、押されたリアクションをreturnする
         if reaction.emoji in emojis:

--- a/Cogs/Managements/selfIntroduction.py
+++ b/Cogs/Managements/selfIntroduction.py
@@ -23,6 +23,7 @@ class Self_Introduction(commands.Cog):
         self.question4 = "\> 得意分野は何ですか？"  # noqa: W605
         self.question5 = "\> 今まで何を勉強してきましたか？"  # noqa: W605
         self.question6 = "\> これから勉強していきたいことは何ですか？"  # noqa: W605
+        self.command_names = ["¥predit"]
 
     # Botを起動したときに__init__に格納したIDからオブジェクトを取得
 
@@ -116,7 +117,7 @@ class Self_Introduction(commands.Cog):
             setattr(obj, column, None)
         obj.mod_column = "nickname"
         session.add(obj)
-        session.flush()
+        session.commit()
 
     def db_update_selfintroduction(self, session, member, select_column,
                                    after_value, next_mod_column) -> None:
@@ -272,39 +273,36 @@ class Self_Introduction(commands.Cog):
         emoji = await self.wait_reaction_add(embed_message, ["👍", "♻️"])
         # 押された絵文字が👍の時(今の内容で登録する)
         if emoji == "👍":
+            # 新しい自己紹介を送信
             after_msg = await self.INTRODUCTION_CHANNEL.send(embed=embed)
+            # 過去の自己紹介を削除
+            await self.delete_before_selfintroduction_msg(session, member)
             # await after_msg.add_reaction("<:yoroshiku:761730298106478592>")
             send_msg2 = "登録が完了しました" \
                 + "\n※登録した自己紹介を修正したい場合は[ ¥predit ]のコマンド(7文字)を送信してください"   # noqa: E501
             await dm.send(embed=self.strfembed(send_msg2))
-            log_msg = f"[INFO] {member.name}の自己紹介が送信されました"
-            # 送信先のメッセージのIDをDBに保存
+            # DBの自己紹介メッセージのIDを過去のIDから新しいIDに更新する
             self.db_update_selfintroduction(session, member, "sendmsg_id",
                                             after_msg.id, None)
-            await self.LOG_CHANNEL.send(log_msg)
         elif emoji == "♻️":
             await self.selfintroduction_reset(session, member, dm)
 
-    async def selfintroduction_msg_update(self, session, member):
-        """
-        既存の自己紹介メッセージが存在する場合は削除し、
-        データ更新後の自己紹介メッセージを送信する
-
-        Parameter
-        ---------
-        member : discord.Member
-            message.authorから取得したメンバーオブジェクト
-        """
+    async def delete_before_selfintroduction_msg(self, session, member):
+        """DBから過去にメッセージを送信した記録があった場合、そのメッセージを削除する"""
         member_data = self.db_select_selfintroduction(session, member)
         channel = self.INTRODUCTION_CHANNEL
         msg_id = member_data.sendmsg_id
+        log_msg = ""
         if msg_id:
             if msg_id.isdecimal():
                 # 既存の自己紹介メッセージを削除
                 selfintroduction_msg = await channel.fetch_message(int(msg_id))
                 await selfintroduction_msg.delete()
-        # 完成した自己紹介を送信
-        await self.send_selfintroduction(session, member)
+                log_msg = f"[INFO] {member.name}の過去の自己紹介が削除・更新しました"
+        if not log_msg:
+            # 新規自己紹介（過去に自己紹介を送信してない）場合
+            log_msg = f"[INFO] {member.name}の自己紹介が送信されました"
+        await self.LOG_CHANNEL.send(log_msg)
 
     async def send_message(self, channel, dm, msgcontent, content):
         """
@@ -499,6 +497,8 @@ class Self_Introduction(commands.Cog):
         # 送信者がbotの場合は無視する
         if message.author.bot:
             return
+        if message.content in self.command_names:
+            return
         dm = await message.author.create_dm()
         member = self.GUILD.get_member(message.author.id)
         session = Selfintroduction.session()
@@ -531,12 +531,12 @@ class Self_Introduction(commands.Cog):
                 await dm.send(embed=self.strfembed(send_msg))
             if next_missingdata_column is None and "sendmsg_id" not in missingdata_column:  # noqa: E501
                 # ¥predit（自己紹介送信済）から一つのカラムを修正した時
-                await self.selfintroduction_msg_update(session, member)
+                await self.send_selfintroduction(session, member)
 
             if "sendmsg_id" in [missingdata_column, next_missingdata_column]:
                 # メッセージを勉強ギルドに送信する処理
-                await self.selfintroduction_msg_update(session, member)
-            session.commit()
+                await self.send_selfintroduction(session, member)
+            # session.commit()
         else:
             # 自己紹介が完成しており、変更カラムもなく送信済み
             send_msg = f"{message.author.name}さんの自己紹介文は既に登録済みです。"\
@@ -561,14 +561,18 @@ class Self_Introduction(commands.Cog):
         for emoji in self.emoji_number:
             await send_embedmsg.add_reaction(emoji)
         await send_embedmsg.add_reaction("♻️")
-        emoji = await self.wait_reaction_add(send_embedmsg, self.emoji_number)
-        # 指定した修正するカラムをDBに保存
-        self.emoji_mod_column(session, member, emoji)
+        check_emojis = self.emoji_number + ["♻️"]
+        emoji = await self.wait_reaction_add(send_embedmsg, check_emojis)
+        if emoji in self.emoji_number:
+            # 指定した修正するカラムをDBに保存
+            self.emoji_mod_column(session, member, emoji)
+            missingdata_column, _ = self.check_missingdata(
+                session, member)
+            send_msg = self.select_nextquestionmsg(missingdata_column)
+            await dm.send(embed=self.strfembed(send_msg))
+        if emoji == "♻️":
+            await self.selfintroduction_reset(session, member, dm)
         # DBのmod_columnから次の質問する内容を選別し、DMで送信する
-        missingdata_column, _ = self.check_missingdata(
-            session, member)
-        send_msg = self.select_nextquestionmsg(missingdata_column)
-        await dm.send(embed=self.strfembed(send_msg))
 
 
 def setup(bot):

--- a/Cogs/Managements/selfIntroduction.py
+++ b/Cogs/Managements/selfIntroduction.py
@@ -60,115 +60,122 @@ class Self_Introduction(commands.Cog):
 これから自己紹介の処理を進めますので、質問に答えて下さい"""))
         await dm.send(embed=self.strfembed(self.question1))
 
-    # DMチャンネルにメッセージが送られた時
+    def db_select_selfintroduction(member, select_colmuns):
+        session = Selfintroduction.session()
+        obj = Selfintroduction.objects(session).filter(
+            Selfintroduction.member_id == member.id,
+            Selfintroduction.guild_id == member.guild.id).first()
+        return obj
 
+    # DMチャンネルにメッセージが送られた時
     @commands.Cog.listener()
+    @commands.dm_only()
     async def on_message(self, message):
-        if isinstance(message.channel, discord.DMChannel):
-            # 送信者がbotの場合は無視する
-            if message.author.bot:
-                return
-            dm = await message.author.create_dm()
-            if message.content == "":
-                await dm.send(embed=self.strfembed("""\
+        # if isinstance(message.channel, discord.DMChannel):
+        # 送信者がbotの場合は無視する
+        if message.author.bot:
+            return
+        dm = await message.author.create_dm()
+        if message.content == "":
+            await dm.send(embed=self.strfembed("""\
 自己紹介の編集中です
 文字列を送信してください"""))
-                return
-            for channel in self.DEBUG_GUILD.text_channels:
-                # DEBUGサーバーからメッセージ送信者のidと同じ名前のTextChannelを見つける
-                if channel.name == str(message.author.id):
-                    # channelを見つけたらそのチャンネル内の合計メッセージ数を取得する
-                    count = await self.get_count(channel)
-                    # メッセージ数が0の時の処理(名前が格納される)
-                    if count == 0:
+            return
+        for channel in self.DEBUG_GUILD.text_channels:
+            # DEBUGサーバーからメッセージ送信者のidと同じ名前のTextChannelを見つける
+            if channel.name == str(message.author.id):
+                # channelを見つけたらそのチャンネル内の合計メッセージ数を取得する
+                count = await self.get_count(channel)
+                # メッセージ数が0の時の処理(名前が格納される)
+                if count == 0:
+                    await self.send_message(channel,
+                                            message.channel,
+                                            message.content,
+                                            f"""\> 性別を教えて下さい。\n{self.question2}""")  # noqa: W605,E501
+                    break
+                # メッセージ数が1の時(性別が格納される)
+                elif count == 1:
+                    if message.content in ["男", "女", "非公開"]:
                         await self.send_message(channel,
                                                 message.channel,
                                                 message.content,
-                                                f"""\> 性別を教えて下さい。\n{self.question2}""")  # noqa: W605,E501
-                        break
-                    # メッセージ数が1の時(性別が格納される)
-                    elif count == 1:
-                        if message.content in ["男", "女", "非公開"]:
-                            await self.send_message(channel,
-                                                    message.channel,
-                                                    message.content,
-                                                    self.question3)
-                        else:
-                            await message.channel.send(self.question2)
-                        break
-                    # メッセージ数が2の時(TwitterIDが格納される)
-                    elif count == 2:
-                        await self.send_message(channel,
-                                                message.channel,
-                                                message.content,
-                                                self.question4)
-                        break
-                    # メッセージ数が3の時(得意分野が格納される)
-                    elif count == 3:
-                        await self.send_message(channel,
-                                                message.channel,
-                                                message.content,
-                                                self.question5)
-                        break
-                    # メッセージ数が4の時(今まで勉強してきたことが格納される)
-                    elif count == 4:
-                        await self.send_message(channel,
-                                                message.channel,
-                                                message.content,
-                                                self.question6)
-                        break
-                    # メッセージ数が5の時(これから勉強していきたいことが格納される)
-                    elif count == 5:
-                        await self.send_message(channel,
-                                                message.channel,
-                                                message.content,
-                                                "これで質問は終了です")
-                        await self.complete(channel,
-                                            message.author.id)
-                        break
-                    elif count == 6:
-                        await self.complete(channel,
-                                            message.author.id)
-                        break
-                    # メッセージ数が7の時
-                    elif count == 7:
-                        await message.channel.send(embed=self.strfembed(f"""\
+                                                self.question3)
+                    else:
+                        await message.channel.send(self.question2)
+                    break
+                # メッセージ数が2の時(TwitterIDが格納される)
+                elif count == 2:
+                    await self.send_message(channel,
+                                            message.channel,
+                                            message.content,
+                                            self.question4)
+                    break
+                # メッセージ数が3の時(得意分野が格納される)
+                elif count == 3:
+                    await self.send_message(channel,
+                                            message.channel,
+                                            message.content,
+                                            self.question5)
+                    break
+                # メッセージ数が4の時(今まで勉強してきたことが格納される)
+                elif count == 4:
+                    await self.send_message(channel,
+                                            message.channel,
+                                            message.content,
+                                            self.question6)
+                    break
+                # メッセージ数が5の時(これから勉強していきたいことが格納される)
+                elif count == 5:
+                    await self.send_message(channel,
+                                            message.channel,
+                                            message.content,
+                                            "これで質問は終了です")
+                    await self.complete(channel,
+                                        message.author.id)
+                    break
+                elif count == 6:
+                    await self.complete(channel,
+                                        message.author.id)
+                    break
+                # メッセージ数が7の時
+                elif count == 7:
+                    await message.channel.send(embed=self.strfembed(f"""\
 {message.author.name}さんの自己紹介文は既に登録済みです。
 変更する場合は、[ ¥predit ]とコマンドを送信して下さい"""))
-                        break
-                    # メッセージ数が8の時、最新メッセージに書かれたメッセージIDの内容を修正
-                    elif count == 8:
-                        messages = await channel.history(limit=None).flatten()
-                        # messages[0]: 修正対象のIDをmessage.contentに格納したメッセージ
-                        # messages[0].content: 修正する対象のメッセージID
-                        # messages[1]: mo9mo9ギルドに送信したメッセージIDをmessage.contentに格納したメッセージ # noqa: E501
-                        # messages[1].content: mo9mo9ギルドに送信された自己紹介メッセージのID
-                        edit_message = await channel.fetch_message(int(messages[0].content))  # noqa: E501
-                        # mo9mo9ギルドに送信した自己紹介メッセージを示すメッセージオブジェクト
-                        selfintroduction_message = await self.INTRODUCTION_CHANNEL.fetch_message(int(messages[1].content))  # noqa: E501
+                    break
+                # メッセージ数が8の時、最新メッセージに書かれたメッセージIDの内容を修正
+                elif count == 8:
+                    messages = await channel.history(limit=None).flatten()
+                    # messages[0]: 修正対象のIDをmessage.contentに格納したメッセージ
+                    # messages[0].content: 修正する対象のメッセージID
+                    # messages[1]: mo9mo9ギルドに送信したメッセージIDをmessage.contentに格納したメッセージ # noqa: E501
+                    # messages[1].content: mo9mo9ギルドに送信された自己紹介メッセージのID
+                    edit_message = await channel.fetch_message(int(messages[0].content))  # noqa: E501
+                    # mo9mo9ギルドに送信した自己紹介メッセージを示すメッセージオブジェクト
+                    selfintroduction_message = await self.INTRODUCTION_CHANNEL.fetch_message(int(messages[1].content))  # noqa: E501
 
-                        # 編集対象のメッセージ内容を修正する
-                        await edit_message.edit(content=message.content)
-                        # 8個目の編集対象を示すメッセージオブジェクト削除
-                        await messages[0].delete()
-                        await selfintroduction_message.delete()
-                        await messages[1].delete()
-                        # 完成した自己紹介を送信する
-                        print(message)
-                        await self.complete(channel, message.author.id)
-                        break
-                    else:
-                        print(
-                            f"{message.author.id}のメッセージの取得数が想定外です： (取得数: {count})")  # noqa: E501
-                        break
-            # DEBUGサーバー内にメッセージ送信者のチャンネルが見つからなかったときに
-            # TextChanenlを作成する
-            else:
-                await self.DEBUG_GUILD.create_text_channel(str(message.author.id))  # noqa: E501
-                await message.channel.send("""\
+                    # 編集対象のメッセージ内容を修正する
+                    await edit_message.edit(content=message.content)
+                    # 8個目の編集対象を示すメッセージオブジェクト削除
+                    await messages[0].delete()
+                    await selfintroduction_message.delete()
+                    await messages[1].delete()
+                    # 完成した自己紹介を送信する
+                    print(message)
+                    await self.complete(channel, message.author.id)
+                    break
+                else:
+                    print(
+                        f"{message.author.id}のメッセージの取得数が想定外です： (取得数: {count})")  # noqa: E501
+                    break
+        # DEBUGサーバー内にメッセージ送信者のチャンネルが見つからなかったときに
+        # TextChanenlを作成する
+        else:
+            await self.DEBUG_GUILD.create_text_channel(str(message.author.id))  # noqa: E501
+            await message.channel.send("""\
 自己紹介文が見つかりませんでした。
 質問に答えると自己紹介が登録できます。""")
-                await message.channel.send(self.question1)
+            await message.channel.send(self.question1)
 
     # ---on_messageイベント内でのみ呼び出される---
     # channelとdmにメッセージを送信するメソッド

--- a/Cogs/Managements/selfIntroduction.py
+++ b/Cogs/Managements/selfIntroduction.py
@@ -11,6 +11,7 @@ class Self_Introduction(commands.Cog):
         self.GUILD_ID = 603582455756095488  # mo9mo9サーバーのID
         self.INTRODUCTION_CHANNEL_ID = 615185771565023244  # mo9mo9の自己紹介チャンネル
         self.DEBUG_GUILD_ID = 795337147149189148  # DEBUGサーバーのID ※変更不可
+        self.emoji_number = ["1⃣", "2⃣", "3⃣", "4⃣", "5⃣", "6⃣"]
         # 以下、質問６項目
         self.question1 = "\> 呼び名を教えてください"  # noqa: W605
         self.question2 = "\> [男/女/非公開]から選んで送信してください"  # noqa: W605
@@ -213,6 +214,277 @@ class Self_Introduction(commands.Cog):
                     check_msg = False
         return check_msg
 
+    async def send_selfintroduction(self, member) -> None:
+        """
+        DBに補完された自己紹介データをEmbedの形に入れ込み、自己紹介を送信する
+
+        Parameter
+        ---------
+        member : discord.Member
+            message.authorから取得したメンバーオブジェクト
+        """
+        dm = await member.create_dm()
+        embed = self.add_embed(member)
+        # 完成した自己紹介文の最終チェック(修正が可能)
+        embed_message = await dm.send(embed=embed)
+        send_msg = "この内容で自己紹介を登録しますか？"\
+            + "OKなら👍リアクションを、修正する場合は♻️リアクションを押して下さい。"\
+            + "部分的に修正する場合は一度👍リアクションを押して投稿した後に修正可能になります"  # noqa: E501
+        await dm.send(embed=self.strfembed(send_msg))
+        # リアクションを追加
+        await embed_message.add_reaction("👍")
+        await embed_message.add_reaction("♻️")
+        # 押されたemojiを取得
+        emoji = await self.wait_reaction_add(embed_message, ["👍", "♻️"])
+        # 押された絵文字が👍の時(今の内容で登録する)
+        if emoji == "👍":
+            after_msg = await self.INTRODUCTION_CHANNEL.send(embed=embed)
+            await after_msg.add_reaction("<:yoroshiku:761730298106478592>")
+            # DBの自己紹介メッセージIDを送信後のメッセージIDに変更
+            await self.db_update_selfintroduction(member, "sendmsg_id",
+                                                  after_msg.id, None)
+            send_msg2 = "登録が完了しました" \
+                + "※登録した自己紹介を修正したい場合は[ ¥predit ]のコマンド(7文字)を送信してください"   # noqa: E501
+            await dm.send(embed=self.strfembed(send_msg2))
+        elif emoji == "♻️":
+            await self.selfintroduction_reset(dm)
+
+    async def selfintroduction_msg_update(self, member):
+        """
+        既存の自己紹介メッセージが存在する場合は削除し、
+        データ更新後の自己紹介メッセージを送信する
+
+        Parameter
+        ---------
+        member : discord.Member
+            message.authorから取得したメンバーオブジェクト
+        """
+        member_data = self.db_select_selfintroduction(member)
+        channel = self.INTRODUCTION_CHANNEL
+        msg_id = member_data["sendmsg_id"]
+        if msg_id:
+            # 既存の自己紹介メッセージを削除
+            selfintroduction_msg = await channel.fetch_message(msg_id)
+            await selfintroduction_msg.delete()
+        # 完成した自己紹介を送信
+        await self.send_selfintroduction(member)
+
+    async def send_message(self, channel, dm, msgcontent, content):
+        """
+        ---on_messageイベント内でのみ呼び出される---
+        channelとdmにメッセージを送信するメソッド
+        """
+        await channel.send(msgcontent)
+        await dm.send(embed=self.strfembed(content))
+
+    # # ---on_messageイベント内でのみ呼び出される---
+    # # チャンネル内のメッセージ総数を取得し、returnする
+    # async def get_count(self, channel):
+    #     messages = await channel.history(limit=None).flatten()
+    #     return len(messages)
+
+#     # ---全ての質問に答えたときに呼び出される---
+#     async def complete(self, channel, member_id):
+#         member = self.GUILD.get_member(member_id)
+#         print(f"complete: {member}")
+#         # dmオブジェクト作成
+#         dm = await member.create_dm()
+#         # 格納されたメッセージをすべて取得
+#         # embedにして整形
+#         embed = self.add_embed(member)
+#         # 完成した自己紹介文の最終チェック(修正が可能)
+#         embed_message = await dm.send(embed=embed)
+#         senf_msg =
+#         await dm.send(embed=self.strfembed("""\
+# この内容で自己紹介を登録しますか？
+# OKなら👍リアクションを、修正する場合は♻️リアクションを押して下さい。
+# 部分的に修正する場合は一度👍リアクションを押して投稿した後に修正可能になります"""))
+#         # リアクションを追加
+#         await embed_message.add_reaction("👍")
+#         await embed_message.add_reaction("♻️")
+#         # 押されたemojiを取得
+#         emoji = await self.wait_reaction_add(channel,
+#                                              embed_message, ["👍", "♻️"])
+#         # 押された絵文字が👍の時(今の内容で登録する)
+#         if emoji == "👍":
+#             register_msg = await self.INTRODUCTION_CHANNEL.send(embed=embed)
+#             await register_msg.add_reaction("<:yoroshiku:761730298106478592>")  # noqa: E501
+#             await channel.send(register_msg.id)
+#             send_msg2 = "登録が完了しました" \
+#                 + "※登録した自己紹介を修正したい場合は[ ¥predit ]とコマンドを送信してください"  # noqa: E501
+#             await dm.send(embed=self.strfembed(send_msg2))
+#         elif emoji == "♻️":
+#             await self.selfintroduction_reset(dm)
+
+    # 自己紹介を初期化する処理
+    async def selfintroduction_reset(self, dm) -> None:
+        """
+        DBの自己紹介データを初期化する処理
+        ギルド・メンバーID、自己紹介が送信済みなら送信済みのカラムは変更しない
+        その他のカラムをNoneに書き換える
+
+        Parameter
+        ---------
+        dm : Discord.dm
+            BOTにDMしたメンバーのDMオブジェクト
+        """
+        await dm.send(embed=self.strfembed("内容を全てリセットします"))
+        # TextChannelを再度作成し直し、リセットする
+        member = self.GUILD.get_member(dm.me.id)
+        self.db_reset_selfintroduction(member)
+        await dm.send(embed=self.strfembed(self.question1))
+
+    def strfembed(self, str):
+        """
+        ---completeメソッド内でのみ呼び出される---
+        文字列をembedに変換する処理
+
+        Parameter
+        ---------
+        str :　str
+            embedに変換したい文字列
+
+        Return
+        ------
+        embed : Discord.Embed
+            strをDiscord.Embedに変換したオブジェクト
+        """
+        embed = discord.Embed(title=str)
+        return embed
+
+    # 質問内容を追加する場合は、ここを弄る
+    def add_embed(self, member):
+        """
+        自己紹介メッセージを作成するテンプレート
+        DBから自己紹介データを取得し、
+        自己紹介メッセージの完成形を作成する
+
+        Parameter
+        ---------
+        member : discord.Member
+            message.authorから取得したメンバーオブジェクト
+
+        Return
+        ------
+        embed : discord.Embed
+            自己紹介メッセージの完成版のembedオブジェクト
+        """
+        obj = self.db_select_selfintroduction(member)
+        embed = discord.Embed(
+            title="自己紹介",
+            description=f"name: {member.name}\njoined: {str(member.joined_at.strftime('%Y-%m-%d'))}",  # noqa: E501
+            color=self.gender_color(obj['sex']))
+        embed.set_thumbnail(url=member.avatar_url)
+        embed.add_field(name="【 __呼び名__ 】",
+                        value=f":name_badge: {obj['nickname']}",
+                        inline=False)
+        embed.add_field(name="【 __TwitterID__ 】",
+                        value=f":globe_with_meridians: @{obj['twitter_id']}",
+                        inline=False)
+        embed.add_field(name="【 __得意分野__ 】",
+                        value=f":ideograph_advantage: {obj['specialty']}",
+                        inline=False)
+        embed.add_field(name="【 __今まで勉強してきたこと__ 】",
+                        value=f":books: {obj['before_study']}",
+                        inline=False)
+        embed.add_field(name="【 __これから勉強していきたいこと__ 】",
+                        value=f":pencil: {obj['after_study']}",
+                        inline=False)
+        embed.set_footer(text=f"{member.id}")
+        return embed
+
+    # ---add_embedメソッド内でのみ呼び出される---
+    # 入力された性別によって、embedのカラーを変える
+    def gender_color(self, gender):
+        if gender in "男":
+            return 0x4093cf
+        elif gender in "女":
+            return 0xba3fb4
+        elif gender in "非公開":
+            return 0x51c447
+
+    # # ---completeメソッド内でのみ呼び出される---
+    # # channel内のメッセージlistの並びを逆にし、
+    # # disocrd.Messageオブジェクトじゃなくdiscord.Message.Contentを格納
+    # def adjust(self, messages):
+    #     messages.reverse()
+    #     return list(map(lambda messages: messages.content, messages))
+
+    def messages_id(self, messages):
+        return list(map(lambda messages: messages.id, messages))
+
+    # ---completeメソッド内でのみ呼び出される---
+    # リアクションが押されたら、そのリアクションをreturnする
+    async def wait_reaction_add(self, message, emojis):
+        """
+        リアクションを押したユーザーがbotじゃなく、
+        押された絵文字がemojisに格納されている絵文字あり、
+        リアクションを押したメッセージのidが送信されたembedメッセージのidと同じで、
+        リアクションを押したユーザーのidとDEBUGサーバー内のchannel名が一致した場合のみ、処理が走る
+
+        Parameter
+        ---------
+        message : discord.Message
+            自己紹介完成後の送信前の確認用のembedメッセージオブジェクト
+        emojis : list
+            確認用のembedメッセージに付与されて処理を通す絵文字の一覧
+        """
+        def check(reaction, user):
+            return user.bot is False and reaction.emoji in emojis and reaction.message.id == message.id  # noqa: E501
+        reaction, user = await self.bot.wait_for('reaction_add', check=check)
+        # リアクションが押されたら、押されたリアクションをreturnする
+        if reaction.emoji in emojis:
+            return reaction.emoji
+
+    def current_setting(self, member, number):
+        obj = self.db_select_selfintroduction(member)
+        desc = f"修正したい項目があればこのメッセージに付与されたリアクション（{number[0]}〜{number[4]}）を押してください"  # noqa: E501
+        embed = discord.Embed(
+            title="現在自己紹介を修正",
+            description=desc,
+            color=self.gender_color(list[1]))
+        embed.add_field(name=f"{number[0]}",
+                        value=obj['nickname'], inline=False)
+        embed.add_field(name=f"{number[1]}", value=obj['sex'], inline=False)
+        embed.add_field(name=f"{number[2]}",
+                        value=obj['twitter_id'], inline=False)
+        embed.add_field(name=f"{number[3]}",
+                        value=obj['specialty'], inline=False)
+        embed.add_field(name=f"{number[4]}",
+                        value=obj['before_study'], inline=False)
+        embed.add_field(name=f"{number[5]}",
+                        value=obj['after_study'], inline=False)
+        embed.add_field(
+            name="♻️",
+            value="初期化してもう一度初めから自己紹介を作成する場合",
+            inline=False)
+        return embed
+
+    def emoji_mod_column(self, member, emoji):
+        send_msg = f"[INFO] BOTのDMで{member.name}が{emoji}のリアクションを押下"
+        print(send_msg)
+        if emoji in self.emoji_number:
+            if emoji == "1⃣":
+                select_column = "nickname"
+            elif emoji == "2⃣":
+                select_column = "sex"
+            elif emoji == "3⃣":
+                select_column = "twitter_id"
+            elif emoji == "4⃣":
+                select_column = "specialty"
+            elif emoji == "5⃣":
+                select_column = "before_study"
+            elif emoji == "6⃣":
+                select_column = "after_study"
+            self.db_update_selfintroduction("mod_column", select_column, None)
+        elif emoji == "♻️":
+            self.db_reset_selfintroduction(member)
+        else:
+            # 想定する絵文字以外のリアクションが発生した場合
+            log_msg = "[WARNING] 想定しないリアクションです"
+            print(log_msg)
+            return
+
     @commands.Cog.listener()
     @commands.dm_only()
     async def on_message(self, message):
@@ -248,296 +520,38 @@ class Self_Introduction(commands.Cog):
             await message.channel.send(embed=self.strfembed(comp_msg))
             return
         # メッセージを勉強ギルドに送信する処理
+        self.selfintroduction_msg_update(member)
         # ここ続けて書く必要あり
 
-    async def send_selfintroduction(self, member) -> None:
-        """
-        DBに補完された自己紹介データをEmbedの形に入れ込み、自己紹介を送信する
-
-        Parameter
-        ---------
-        member : discord.Member
-            message.authorから取得したメンバーオブジェクト
-        """
-        dm = await member.create_dm()
-        embed = self.add_embed(member)
-        # 完成した自己紹介文の最終チェック(修正が可能)
-        embed_message = await dm.send(embed=embed)
-        send_msg = "この内容で自己紹介を登録しますか？"\
-            + "OKなら👍リアクションを、修正する場合は♻️リアクションを押して下さい。"\
-            + "部分的に修正する場合は一度👍リアクションを押して投稿した後に修正可能になります"  # noqa: E501
-        await dm.send(embed=self.strfembed(send_msg))
-        # リアクションを追加
-        await embed_message.add_reaction("👍")
-        await embed_message.add_reaction("♻️")
-        # 押されたemojiを取得
-        emoji = await self.wait_reaction_add(embed_message, ["👍", "♻️"])
-        # 押された絵文字が👍の時(今の内容で登録する)
-        if emoji == "👍":
-            after_msg = await self.INTRODUCTION_CHANNEL.send(embed=embed)
-            await after_msg.add_reaction("<:yoroshiku:761730298106478592>")
-            # DBの自己紹介メッセージIDを送信後のメッセージIDに変更
-            await self.db_update_selfintroduction(member, "sendmsg_id",
-                                                  after_msg.id, None)
-            send_msg2 = "登録が完了しました" \
-                + "※登録した自己紹介を修正したい場合は[ ¥predit ]とコマンドを送信してください"   # noqa: E501
-            await dm.send(embed=self.strfembed(send_msg2))
-        elif emoji == "♻️":
-            await self.selfintroduction_reset(dm)
-
-    async def selfintroduction_msg_update(self, member):
-        member_data = self.db_select_selfintroduction(member)
-        channel = self.INTRODUCTION_CHANNEL
-        msg_id = member_data["sendmsg_id"]
-        if msg_id:
-            # 既存の自己紹介メッセージを削除
-            selfintroduction_msg = await channel.fetch_message(msg_id)
-            await selfintroduction_msg.delete()
-        # 完成した自己紹介を送信
-        await self.send_selfintroduction(member)
-
-    async def send_message(self, channel, dm, msgcontent, content):
-        """
-        ---on_messageイベント内でのみ呼び出される---
-        channelとdmにメッセージを送信するメソッド
-        """
-        await channel.send(msgcontent)
-        await dm.send(embed=self.strfembed(content))
-
-    # ---on_messageイベント内でのみ呼び出される---
-    # チャンネル内のメッセージ総数を取得し、returnする
-    async def get_count(self, channel):
-        messages = await channel.history(limit=None).flatten()
-        return len(messages)
-
-    # ---全ての質問に答えたときに呼び出される---
-    async def complete(self, channel, member_id):
-        member = self.GUILD.get_member(member_id)
-        print(f"complete: {member}")
-        # dmオブジェクト作成
-        dm = await member.create_dm()
-        # 格納されたメッセージをすべて取得
-        # embedにして整形
-        embed = self.add_embed(member)
-        # 完成した自己紹介文の最終チェック(修正が可能)
-        embed_message = await dm.send(embed=embed)
-        await dm.send(embed=self.strfembed("""\
-この内容で自己紹介を登録しますか？
-OKなら👍リアクションを、修正する場合は♻️リアクションを押して下さい。
-部分的に修正する場合は一度👍リアクションを押して投稿した後に修正可能になります"""))
-        # リアクションを追加
-        await embed_message.add_reaction("👍")
-        await embed_message.add_reaction("♻️")
-        # 押されたemojiを取得
-        emoji = await self.wait_reaction_add(channel,
-                                             embed_message, ["👍", "♻️"])
-        # 押された絵文字が👍の時(今の内容で登録する)
-        if emoji == "👍":
-            register_msg = await self.INTRODUCTION_CHANNEL.send(embed=embed)
-            await register_msg.add_reaction("<:yoroshiku:761730298106478592>")
-            await channel.send(register_msg.id)
-            send_msg2 = "登録が完了しました" \
-                + "※登録した自己紹介を修正したい場合は[ ¥predit ]とコマンドを送信してください"  # noqa: E501
-            await dm.send(embed=self.strfembed(send_msg2))
-        elif emoji == "♻️":
-            await self.selfintroduction_reset(dm)
-
-    # 自己紹介を初期化する処理
-    async def selfintroduction_reset(self, dm) -> None:
-        """
-        DBの自己紹介データを初期化する処理
-        ギルド・メンバーID、自己紹介が送信済みなら送信済みのカラムは変更しない
-        その他のカラムをNoneに書き換える
-
-        Parameter
-        ---------
-        dm : Discord.dm
-            BOTにDMしたメンバーのDMオブジェクト
-        """
-        await dm.send(embed=self.strfembed("内容を全てリセットします"))
-        # TextChannelを再度作成し直し、リセットする
-        member = self.GUILD.get_member(dm.me.id)
-        self.db_reset_selfintroduction(member)
-        await dm.send(embed=self.strfembed(self.question1))
-
-    # ---completeメソッド内でのみ呼び出される---
-    # Embedオブジェクトを作成するメソッド
-
-    def strfembed(self, str):
-        """
-        文字列をembedに変換する処理
-
-        Parameter
-        ---------
-        str :　str
-            embedに変換したい文字列
-
-        Return
-        ------
-        embed : Discord.Embed
-            strをDiscord.Embedに変換したオブジェクト
-        """
-        embed = discord.Embed(title=str)
-        return embed
-
-    # 質問内容を追加する場合は、ここを弄る
-    def add_embed(self, member):
-        obj = self.db_select_selfintroduction(member)
-        embed = discord.Embed(
-            title="自己紹介",
-            description=f"name: {member.name}\njoined: {str(member.joined_at.strftime('%Y-%m-%d'))}",  # noqa: E501
-            color=self.gender_color(obj['sex']))
-        embed.set_thumbnail(url=member.avatar_url)
-        embed.add_field(name="【 __呼び名__ 】",
-                        value=f":name_badge: {obj['nickname']}",
-                        inline=False)
-        embed.add_field(name="【 __TwitterID__ 】",
-                        value=f":globe_with_meridians: @{obj['twitter_id']}",
-                        inline=False)
-        embed.add_field(name="【 __得意分野__ 】",
-                        value=f":ideograph_advantage: {obj['specialty']}",
-                        inline=False)
-        embed.add_field(name="【 __今まで勉強してきたこと__ 】",
-                        value=f":books: {obj['before_study']}",
-                        inline=False)
-        embed.add_field(name="【 __これから勉強していきたいこと__ 】",
-                        value=f":pencil: {obj['after_study']}",
-                        inline=False)
-        embed.set_footer(text=f"{member.id}")
-        return embed
-
-    # ---add_embedメソッド内でのみ呼び出される---
-    # 入力された性別によって、embedのカラーを変える
-    def gender_color(self, gender):
-        if gender in "男":
-            return 0x4093cf
-        elif gender in "女":
-            return 0xba3fb4
-        elif gender in "非公開":
-            return 0x51c447
-
-    # ---completeメソッド内でのみ呼び出される---
-    # channel内のメッセージlistの並びを逆にし、
-    # disocrd.Messageオブジェクトじゃなくdiscord.Message.Contentを格納
-    def adjust(self, messages):
-        messages.reverse()
-        return list(map(lambda messages: messages.content, messages))
-
-    def messages_id(self, messages):
-        return list(map(lambda messages: messages.id, messages))
-
-    # ---completeメソッド内でのみ呼び出される---
-    # リアクションが押されたら、そのリアクションをreturnする
-    async def wait_reaction_add(self, message, emojis):
-        """
-        リアクションを押したユーザーがbotじゃなく、
-        押された絵文字がemojisに格納されている絵文字あり、
-        リアクションを押したメッセージのidが送信されたembedメッセージのidと同じで、
-        リアクションを押したユーザーのidとDEBUGサーバー内のchannel名が一致した場合のみ、処理が走る
-
-        Parameter
-        ---------
-        message : discord.Message
-            自己紹介完成後の送信前の確認用のembedメッセージオブジェクト
-        emojis : list
-            確認用のembedメッセージに付与されて処理を通す絵文字の一覧
-        """
-        def check(reaction, user):
-            return user.bot is False and reaction.emoji in emojis and reaction.message.id == message.id  # noqa: E501
-        reaction, user = await self.bot.wait_for('reaction_add', check=check)
-        # リアクションが押されたら、押されたリアクションをreturnする
-        if reaction.emoji in emojis:
-            return reaction.emoji
-
-    def current_setting(self, list, member, number):
-        desc = f"修正したい項目があればこのメッセージに付与されたリアクション（{number[0]}〜{number[4]}）を押してください"  # noqa: E501
-        embed = discord.Embed(
-            title="現在自己紹介を修正",
-            description=desc,
-            color=self.gender_color(list[1]))
-        embed.add_field(name=f"{number[0]}", value=f"{list[0]}", inline=False)
-        embed.add_field(name=f"{number[1]}", value=f"{list[2]}", inline=False)
-        embed.add_field(name=f"{number[2]}", value=f"{list[3]}", inline=False)
-        embed.add_field(name=f"{number[3]}", value=f"{list[4]}", inline=False)
-        embed.add_field(name=f"{number[4]}", value=f"{list[5]}", inline=False)
-        embed.add_field(
-            name="♻️",
-            value="初期化してもう一度初めから自己紹介を作成する場合",
-            inline=False)
-        return embed
-
     @commands.command()
+    @commands.dm_only()
     async def predit(self, message):
-        if not isinstance(message.channel, discord.DMChannel):
-            return
+        """
+        既存の自己紹介データを送信し、修正するカラムをメンバーに指定してもらう
+        リアクションで対象のカラムを指定し、mod_columnに対象カラムを保存する
+        """
+        # if not isinstance(message.channel, discord.DMChannel):
+        #     return
         member = self.GUILD.get_member(message.author.id)
         dm = await message.author.create_dm()
-        for channel in self.DEBUG_GUILD.text_channels:
-            if channel.name == str(message.author.id):
-                # channelを見つけたらそのチャンネル内の合計メッセージ数を取得する
-                messages = await channel.history(limit=None).flatten()
-                if len(messages) != 7:
-                    await dm.send(embed=self.strfembed("""\
-自己紹介を登録してから[ ¥predit ]コマンドを使用して下さい。
-何かメッセージを送信してみてください"""))
-                    break
-                # 修正項目を指定するためのリアクションのemojiを配列に格納
-                emoji_number = ["1⃣", "2⃣", "3⃣", "4⃣", "5⃣"]
-                embed = self.current_setting(
-                    self.adjust(messages), member, emoji_number)
-                embed_message = await dm.send(embed=embed)
-                for emoji in emoji_number:
-                    await embed_message.add_reaction(emoji)
-                await embed_message.add_reaction("♻️")
-                emoji_number.append("♻️")
-                emoji = await self.wait_reaction_add(channel,
-                                                     embed_message,
-                                                     emoji_number)
-                pr_messages = self.messages_id(messages)
-                if emoji == "1⃣":
-                    print(f"[INFO]: {member.name}: {emoji} のリアクションが押されました")
-                    await self.send_message(channel,
-                                            dm,
-                                            pr_messages[0],
-                                            self.question1)
-                    break
-                if emoji == "2⃣":
-                    print(f"[INFO]: {member.name}: {emoji} のリアクションが押されました")
-                    await self.send_message(channel,
-                                            dm,
-                                            pr_messages[2],
-                                            self.question3)
-                    break
-                if emoji == "3⃣":
-                    print(f"[INFO]: {member.name}: {emoji} のリアクションが押されました")
-                    await self.send_message(channel,
-                                            dm,
-                                            pr_messages[3],
-                                            self.question4)
-                    break
-                if emoji == "4⃣":
-                    print(f"[INFO]: {member.name}: {emoji} のリアクションが押されました")
-                    await self.send_message(channel,
-                                            dm,
-                                            pr_messages[4],
-                                            self.question5)
-                    break
-                if emoji == "5⃣":
-                    print(f"[INFO]: {member.name}: {emoji} のリアクションが押されました")
-                    await self.send_message(channel,
-                                            dm, pr_messages[5],
-                                            self.question6)
-                    break
-                if emoji == "♻️":
-                    print(f"[INFO]: {member.name}: {emoji} のリアクションが押されました")
-                    await self.selfintroduction_reset(channel, message.channel)
-                    break
-        else:
-            await self.DEBUG_GUILD.create_text_channel(str(message.author.id))
-            await dm.send(embed=self.strfembed("""\
-自己紹介文が見つかりませんでした。
-質問に答えると自己紹介が登録できます。"""))
-            await dm.send(embed=self.strfembed(self.question1))
+        # if 自己紹介送信済みであること、mod_columnがNoneであること
+        #     send_msg = "自己紹介を登録してから[ ¥predit ]コマンド(7文字)を使用して下さい。" \
+        #         + "何かメッセージを送信してみてください"
+        #     await dm.send(embed=self.strfembed("send_msg"))
+        embed = self.current_setting(member, self.emoji_number)
+        send_embedmsg = await dm.send(embed=embed)
+        # メッセージにリアクションを付与
+        for emoji in self.emoji_number:
+            await send_embedmsg.add_reaction(emoji)
+        await send_embedmsg.add_reaction("♻️")
+        emoji = await self.wait_reaction_add(message, self.emoji_number)
+        # 指定した修正するカラムをDBに保存
+        self.emoji_mod_column(member, emoji)
+        # DBのmod_columnから次の質問する内容を選別し、DMで送信する
+        missingdata_column, _ = self.check_missingdata(
+            member)
+        send_msg = self.select_nextquestionmsg(missingdata_column)
+        await dm.send(embed=self.strfembed(send_msg))
 
 
 def setup(bot):

--- a/Cogs/Managements/selfIntroduction.py
+++ b/Cogs/Managements/selfIntroduction.py
@@ -10,7 +10,7 @@ class Self_Introduction(commands.Cog):
         self.bot = bot
         self.GUILD_ID = 603582455756095488  # mo9mo9サーバーのID
         self.INTRODUCTION_CHANNEL_ID = 615185771565023244  # mo9mo9の自己紹介チャンネル
-        self.DEBUG_GUILD_ID = 795337147149189148  # DEBUGサーバーのID ※変更不可
+        self.LOG_CHANNEL_ID = 801060150433153054
         self.emoji_number = ["1⃣", "2⃣", "3⃣", "4⃣", "5⃣", "6⃣"]
         # 以下、質問６項目
         self.question1 = "\> 呼び名を教えてください"  # noqa: W605
@@ -27,21 +27,31 @@ class Self_Introduction(commands.Cog):
         self.GUILD = self.bot.get_guild(self.GUILD_ID)
         self.INTRODUCTION_CHANNEL = self.GUILD.get_channel(
             self.INTRODUCTION_CHANNEL_ID)
-        self.DEBUG_GUILD = self.bot.get_guild(self.DEBUG_GUILD_ID)
+        self.LOG_CHANNEL = self.GUILD.get_channel(self.LOG_CHANNEL_ID)
         # 全てのパラメータが埋まっている状態で、まだ自己紹介を送信していない場合
+        # 後ほど必要になるだろう処理
+
         # 再度確認用のメッセージをDMに送る処理追加
-        guild = self.bot.get_guild(self.GUILD_ID)
-        for channel in self.DEBUG_GUILD.text_channels:
-            count = await self.get_count(channel)
-            if count == 6:
-                member = guild.get_member(
-                    int(channel.name))
-                print(f"自己紹介を送信していないユーザー: {member}/{channel}")
-                if member is None:
-                    return
-                await self.complete(channel, member.id)
+        # for channel in self.DEBUG_GUILD.text_channels:
+        #     count = await self.get_count(channel)
+        #     if count == 6:
+        #         member = guild.get_member(
+        #             int(channel.name))
+        #         print(f"自己紹介を送信していないユーザー: {member}/{channel}")
+        #         if member is None:
+        #             return
+        #         await self.complete(channel, member.id)
 
     async def db_insert_selfintroduction(self, member):
+        """
+        メンバー参加時、その他レコードが存在しない時に対象メンバーのレコードを作成
+        ギルドID,メンバーID,次修正するカラムに"nickname"を挿入する
+
+        Parameter
+        ---------
+        member : discord.Member
+            message.authorから取得したメンバーオブジェクト
+        """
         obj = Selfintroduction(
             guild_id=member.guild.id,
             member_id=member.id,
@@ -246,6 +256,8 @@ class Self_Introduction(commands.Cog):
             send_msg2 = "登録が完了しました" \
                 + "※登録した自己紹介を修正したい場合は[ ¥predit ]のコマンド(7文字)を送信してください"   # noqa: E501
             await dm.send(embed=self.strfembed(send_msg2))
+            log_msg = f"[INFO] {member.name}の自己紹介が送信されました"
+            await self.LOG_CHANNEL.send(log_msg)
         elif emoji == "♻️":
             await self.selfintroduction_reset(dm)
 
@@ -277,45 +289,6 @@ class Self_Introduction(commands.Cog):
         await channel.send(msgcontent)
         await dm.send(embed=self.strfembed(content))
 
-    # # ---on_messageイベント内でのみ呼び出される---
-    # # チャンネル内のメッセージ総数を取得し、returnする
-    # async def get_count(self, channel):
-    #     messages = await channel.history(limit=None).flatten()
-    #     return len(messages)
-
-#     # ---全ての質問に答えたときに呼び出される---
-#     async def complete(self, channel, member_id):
-#         member = self.GUILD.get_member(member_id)
-#         print(f"complete: {member}")
-#         # dmオブジェクト作成
-#         dm = await member.create_dm()
-#         # 格納されたメッセージをすべて取得
-#         # embedにして整形
-#         embed = self.add_embed(member)
-#         # 完成した自己紹介文の最終チェック(修正が可能)
-#         embed_message = await dm.send(embed=embed)
-#         senf_msg =
-#         await dm.send(embed=self.strfembed("""\
-# この内容で自己紹介を登録しますか？
-# OKなら👍リアクションを、修正する場合は♻️リアクションを押して下さい。
-# 部分的に修正する場合は一度👍リアクションを押して投稿した後に修正可能になります"""))
-#         # リアクションを追加
-#         await embed_message.add_reaction("👍")
-#         await embed_message.add_reaction("♻️")
-#         # 押されたemojiを取得
-#         emoji = await self.wait_reaction_add(channel,
-#                                              embed_message, ["👍", "♻️"])
-#         # 押された絵文字が👍の時(今の内容で登録する)
-#         if emoji == "👍":
-#             register_msg = await self.INTRODUCTION_CHANNEL.send(embed=embed)
-#             await register_msg.add_reaction("<:yoroshiku:761730298106478592>")  # noqa: E501
-#             await channel.send(register_msg.id)
-#             send_msg2 = "登録が完了しました" \
-#                 + "※登録した自己紹介を修正したい場合は[ ¥predit ]とコマンドを送信してください"  # noqa: E501
-#             await dm.send(embed=self.strfembed(send_msg2))
-#         elif emoji == "♻️":
-#             await self.selfintroduction_reset(dm)
-
     # 自己紹介を初期化する処理
     async def selfintroduction_reset(self, dm) -> None:
         """
@@ -334,7 +307,7 @@ class Self_Introduction(commands.Cog):
         self.db_reset_selfintroduction(member)
         await dm.send(embed=self.strfembed(self.question1))
 
-    def strfembed(self, str):
+    def strfembed(self, str) -> discord.Embed:
         """
         ---completeメソッド内でのみ呼び出される---
         文字列をembedに変換する処理
@@ -353,7 +326,7 @@ class Self_Introduction(commands.Cog):
         return embed
 
     # 質問内容を追加する場合は、ここを弄る
-    def add_embed(self, member):
+    def add_embed(self, member) -> discord.Embed:
         """
         自己紹介メッセージを作成するテンプレート
         DBから自己紹介データを取得し、
@@ -393,22 +366,26 @@ class Self_Introduction(commands.Cog):
         embed.set_footer(text=f"{member.id}")
         return embed
 
-    # ---add_embedメソッド内でのみ呼び出される---
-    # 入力された性別によって、embedのカラーを変える
-    def gender_color(self, gender):
+    def gender_color(self, gender) -> int:
+        """
+        入力された性別によって、embedのカラーを変える
+
+        Parameter
+        ---------
+        gender : str
+            メンバーが指定した性別を格納している
+
+        Return
+        ------
+        int
+            16進数のカラーコード
+        """
         if gender in "男":
             return 0x4093cf
         elif gender in "女":
             return 0xba3fb4
         elif gender in "非公開":
             return 0x51c447
-
-    # # ---completeメソッド内でのみ呼び出される---
-    # # channel内のメッセージlistの並びを逆にし、
-    # # disocrd.Messageオブジェクトじゃなくdiscord.Message.Contentを格納
-    # def adjust(self, messages):
-    #     messages.reverse()
-    #     return list(map(lambda messages: messages.content, messages))
 
     def messages_id(self, messages):
         return list(map(lambda messages: messages.id, messages))
@@ -438,11 +415,11 @@ class Self_Introduction(commands.Cog):
 
     def current_setting(self, member, number):
         obj = self.db_select_selfintroduction(member)
-        desc = f"修正したい項目があればこのメッセージに付与されたリアクション（{number[0]}〜{number[4]}）を押してください"  # noqa: E501
+        desc = f"修正したい項目があればこのメッセージに付与されたリアクション（{number[0]}〜{number[-1]}）を押してください"  # noqa: E501
         embed = discord.Embed(
             title="現在自己紹介を修正",
             description=desc,
-            color=self.gender_color(list[1]))
+            color=self.gender_color(obj['sex']))
         embed.add_field(name=f"{number[0]}",
                         value=obj['nickname'], inline=False)
         embed.add_field(name=f"{number[1]}", value=obj['sex'], inline=False)

--- a/Cogs/Managements/selfIntroduction.py
+++ b/Cogs/Managements/selfIntroduction.py
@@ -490,20 +490,22 @@ class Self_Introduction(commands.Cog):
             return
 
     @commands.Cog.listener()
-    @commands.dm_only()
     async def on_message(self, message):
         """
         メンバーとBOT間のDMをトリガーに実行される
         """
-        # if isinstance(message.channel, discord.DMChannel):
+        if not isinstance(message.channel, discord.DMChannel):
+            return
         # 送信者がbotの場合は無視する
         if message.author.bot:
             return
         dm = await message.author.create_dm()
         member = self.GUILD.get_member(message.author.id)
+        session = Selfintroduction.session()
+        # メンバーのレコードが存在しない場合には新規作成
+        await self.db_insert_selfintroduction(session, member)
         # 受信したメッセージの内容をどのカラムに保存するかを確認
         # 次不足しているデータの確認
-        session = Selfintroduction.session()
         missingdata_column, next_missingdata_column = self.check_missingdata(
             session, member)
         if missingdata_column != "sendmsg_id":
@@ -543,14 +545,13 @@ class Self_Introduction(commands.Cog):
             return
 
     @commands.command()
-    # @commands.dm_only()
     async def predit(self, message):
         """
         既存の自己紹介データを送信し、修正するカラムをメンバーに指定してもらう
         リアクションで対象のカラムを指定し、mod_columnに対象カラムを保存する
         """
-        # if not isinstance(message.channel, discord.DMChannel):
-        #     return
+        if not isinstance(message.channel, discord.DMChannel):
+            return
         member = self.GUILD.get_member(message.author.id)
         dm = await message.author.create_dm()
         session = Selfintroduction.session()

--- a/Cogs/Managements/selfIntroduction.py
+++ b/Cogs/Managements/selfIntroduction.py
@@ -304,14 +304,6 @@ class Self_Introduction(commands.Cog):
             log_msg = f"[INFO] {member.name}の自己紹介が送信されました"
         await self.LOG_CHANNEL.send(log_msg)
 
-    async def send_message(self, channel, dm, msgcontent, content):
-        """
-        ---on_messageイベント内でのみ呼び出される---
-        channelとdmにメッセージを送信するメソッド
-        """
-        await channel.send(msgcontent)
-        await dm.send(embed=self.strfembed(content))
-
     # 自己紹介を初期化する処理
     async def selfintroduction_reset(self, session, member, dm) -> None:
         """

--- a/Cogs/Managements/selfIntroduction.py
+++ b/Cogs/Managements/selfIntroduction.py
@@ -60,17 +60,56 @@ class Self_Introduction(commands.Cog):
 これから自己紹介の処理を進めますので、質問に答えて下さい"""))
         await dm.send(embed=self.strfembed(self.question1))
 
-    def db_select_selfintroduction(member, select_colmuns):
+    def db_select_selfintroduction(self, member):
+        """
+        対象メンバーの自己紹介データを取得する
+        """
         session = Selfintroduction.session()
         obj = Selfintroduction.objects(session).filter(
             Selfintroduction.member_id == member.id,
             Selfintroduction.guild_id == member.guild.id).first()
         return obj
 
+    def db_update_selfintroduction(self, select_colmuns, after_value):
+        """
+        カラムを指定して自己紹介データを修正する
+        """
+        obj = self.db_select_selfintroduction()
+        obj[select_colmuns] = after_value
+        obj.commit()
+
+    def check_missingdata(self):
+        """
+        修正するカラムを指定している場合、修正しようとしているカラム名を返す
+        修正するカラムを指定していない場合、不足しているデータのカラムを返す
+        """
+        member_data = self.db_select_selfintroduction()
+        if member_data["mod_column"]:
+            missingdata_colmuns = member_data["mod_column"]
+        elif member_data.nickname:
+            missingdata_colmuns = "nickname"
+        elif member_data["sex"]:
+            missingdata_colmuns = "sex"
+        elif member_data["twitter_id"]:
+            missingdata_colmuns = "twitter_id"
+        elif member_data["specialty"]:
+            missingdata_colmuns = "specialty"
+        elif member_data["before_study"]:
+            missingdata_colmuns = "before_study"
+        elif member_data["after_study"]:
+            missingdata_colmuns = "after_study"
+        elif member_data["sendmsg_id"]:
+            missingdata_colmuns = "sendmsg_id"
+        return missingdata_colmuns
+
     # DMチャンネルにメッセージが送られた時
+
     @commands.Cog.listener()
     @commands.dm_only()
     async def on_message(self, message):
+        """
+        メンバーとBOT間のDMをトリガーに実行される
+        """
         # if isinstance(message.channel, discord.DMChannel):
         # 送信者がbotの場合は無視する
         if message.author.bot:

--- a/Cogs/Managements/selfIntroduction.py
+++ b/Cogs/Managements/selfIntroduction.py
@@ -8,9 +8,13 @@ class Self_Introduction(commands.Cog):
 
     def __init__(self, bot):
         self.bot = bot
-        self.GUILD_ID = 603582455756095488  # mo9mo9サーバーのID
-        self.INTRODUCTION_CHANNEL_ID = 615185771565023244  # mo9mo9の自己紹介チャンネル
-        self.LOG_CHANNEL_ID = 801060150433153054
+        # self.GUILD_ID = 603582455756095488  # mo9mo9サーバーのID
+        # self.INTRODUCTION_CHANNEL_ID = 615185771565023244  # mo9mo9の自己紹介チャンネル
+        # self.LOG_CHANNEL_ID = 801060150433153054
+        self.GUILD_ID = 696268022930866177
+        self.INTRODUCTION_CHANNEL_ID = 909813699072643092
+        self.LOG_CHANNEL_ID = 909813908699754516
+
         self.emoji_number = ["1⃣", "2⃣", "3⃣", "4⃣", "5⃣", "6⃣"]
         # 以下、質問６項目
         self.question1 = "\> 呼び名を教えてください"  # noqa: W605
@@ -42,7 +46,7 @@ class Self_Introduction(commands.Cog):
         #             return
         #         await self.complete(channel, member.id)
 
-    async def db_insert_selfintroduction(self, member):
+    async def db_insert_selfintroduction(self, session, member):
         """
         メンバー参加時、その他レコードが存在しない時に対象メンバーのレコードを作成
         ギルドID,メンバーID,次修正するカラムに"nickname"を挿入する
@@ -52,12 +56,15 @@ class Self_Introduction(commands.Cog):
         member : discord.Member
             message.authorから取得したメンバーオブジェクト
         """
-        obj = Selfintroduction(
-            guild_id=member.guild.id,
-            member_id=member.id,
-            mod_column="nickname"
-        )
-        Selfintroduction.insert(obj)
+        member_data = self.db_select_selfintroduction(session, member)
+        if not member_data:
+            # メンバーのレコードが存在しなければ作成する
+            obj = Selfintroduction(
+                guild_id=member.guild.id,
+                member_id=member.id,
+                mod_column="nickname"
+            )
+            Selfintroduction.insert(obj)
 
     # サーバーにメンバーが参加した時
     @commands.Cog.listener()
@@ -71,10 +78,12 @@ class Self_Introduction(commands.Cog):
         # selfintroductionテーブルに参加したメンバーの情報をinsert
         await self.db_insert_selfintroduction(member)
         # 参加者にdmを送る
-        await dm.send(embed=self.strfembed("ギルドへの参加ありがとうございます\nこれから自己紹介の処理を進めますので、質問に答えて下さい"))  # noqa: E501
+        send_msg = "ギルドへの参加ありがとうございます"\
+            + "\nこれから自己紹介の処理を進めますので、質問に答えて下さい"
+        await dm.send(embed=self.strfembed(send_msg))  # noqa: E501
         await dm.send(embed=self.strfembed(self.question1))
 
-    def db_select_selfintroduction(self, member):
+    def db_select_selfintroduction(self, session, member):
         """
         対象メンバーの自己紹介データを取得する
 
@@ -83,13 +92,13 @@ class Self_Introduction(commands.Cog):
         member : discord.Member
             message.authorから取得したメンバーオブジェクト
         """
-        session = Selfintroduction.session()
+        # session = Selfintroduction.session()
         obj = Selfintroduction.objects(session).filter(
             Selfintroduction.member_id == member.id,
             Selfintroduction.guild_id == member.guild.id).first()
         return obj
 
-    def db_reset_selfintroduction(self, member) -> None:
+    def db_reset_selfintroduction(self, session, member) -> None:
         """
         対象メンバーの自己紹介データのメンバーが対話式でデータを挿入できるカラムを初期化
 
@@ -98,19 +107,18 @@ class Self_Introduction(commands.Cog):
         member : discord.Member
             message.authorから取得したメンバーオブジェクト
         """
-        session = Selfintroduction.session()
-        obj = Selfintroduction.objects(session).filter(
-            Selfintroduction.member_id == member.id,
-            Selfintroduction.guild_id == member.guild.id).first()
+        # session = Selfintroduction.session()
+        obj = self.db_select_selfintroduction(session, member)
         reset_columns = ["nickname", "sex", "twitter_id", "specialty",
                          "before_study", "after_study"]
         for column in reset_columns:
-            obj[column] = None
-        obj["mod_column"] = "nickname"
-        obj.commit()
+            setattr(obj, column, None)
+        obj.mod_column = "nickname"
+        session.add(obj)
+        session.flush()
 
-    def db_update_selfintroduction(self, member, select_column, after_value,
-                                   next_mod_column) -> None:
+    def db_update_selfintroduction(self, session, member, select_column,
+                                   after_value, next_mod_column) -> None:
         """
         カラムを指定して自己紹介データを修正する
 
@@ -123,13 +131,24 @@ class Self_Introduction(commands.Cog):
         next_mod_column : str
             カラム名[mod_column]に保存される、次修正対象となるカラム名
         """
-        obj = self.db_select_selfintroduction(member)
-        obj[select_column] = after_value
-        if next_mod_column:
-            obj["mod_column"] = next_mod_column
-        obj.commit()
+        # session = Selfintroduction.session()
+        obj = self.db_select_selfintroduction(session, member)
+        # obj(bind=session)
+        setattr(obj, select_column, after_value)
+        if select_column != "mod_column":
+            # 変更するカラムが"mod_column"以外の時
+            if next_mod_column:
+                # next_mod_columnに値が含まれている時
+                obj.mod_column = next_mod_column
+            else:
+                # 自己紹介送信時にmod_columnをNoneにするため
+                obj.mod_column = None
+        session.add(obj)
+        # session.flush()
+        session.commit()
+        print("[DEBUG] commit")
 
-    def check_missingdata(self, member) -> str:
+    def check_missingdata(self, session, member) -> str:
         """
         DBからメンバーの自己紹介情報を取得し、現在の処理で受け取ったメッセージ内容を
         どのカラムに保存するかをかをmod_columnから確認する
@@ -142,27 +161,28 @@ class Self_Introduction(commands.Cog):
         next_missingdata_column : str, None
             今回の処理が正常に完了した場合、次に修正するカラム名
         """
-        member_data = self.db_select_selfintroduction(member)
+        member_data = self.db_select_selfintroduction(session, member)
+        m_d = member_data
         missingdata_column = None
         next_missingdata_column = None
         # 次修正するカラムを確認
-        if not member_data["nickname"]:
+        if not m_d.nickname and m_d.mod_column != "nickname":
             next_missingdata_column = "nickname"
-        elif not member_data["sex"]:
+        elif not m_d.sex and m_d.mod_column != "sex":
             next_missingdata_column = "sex"
-        elif not member_data["twitter_id"]:
+        elif not m_d.twitter_id and m_d.mod_column != "twitter_id":
             next_missingdata_column = "twitter_id"
-        elif not member_data["specialty"]:
+        elif not m_d.specialty and m_d.mod_column != "specialty":
             next_missingdata_column = "specialty"
-        elif not member_data["before_study"]:
+        elif not m_d.before_study and m_d.mod_column != "before_study":
             next_missingdata_column = "before_study"
-        elif not member_data["after_study"]:
+        elif not m_d.after_study and m_d.mod_column != "after_study":
             next_missingdata_column = "after_study"
-        elif not member_data["sendmsg_id"]:
+        elif not m_d.sendmsg_id and m_d.mod_column != "sendmsg_id":
             next_missingdata_column = "sendmsg_id"
         # 今回修正するカラムを確認
-        if member_data["mod_column"]:
-            missingdata_column = member_data["mod_column"]
+        if m_d.mod_column:
+            missingdata_column = m_d.mod_column
         else:
             # mod_columnには修正するカラムの指定はないが
             # 不足しているデータがあった場合
@@ -199,6 +219,8 @@ class Self_Introduction(commands.Cog):
             next_msg = self.question6
         elif next_missingdata_column == "sendmsg_id":
             next_msg = "これで質問は終了です"
+        elif not next_missingdata_column:
+            next_msg = "これで質問は終了です"
         return next_msg
 
     async def check_msg_content(self, dm, missingdata_column, msg_cont) -> bool:  # noqa: E501
@@ -216,7 +238,8 @@ class Self_Introduction(commands.Cog):
         """
         check_msg = True
         if msg_cont == "":
-            await dm.send(embed=self.strfembed("自己紹介の編集中です\n文字列を送信してください"))
+            send_msg = "自己紹介の編集中です\n文字列を送信してください"
+            await dm.send(embed=self.strfembed(send_msg))
             check_msg = False
         else:
             if missingdata_column == "sex":
@@ -224,7 +247,7 @@ class Self_Introduction(commands.Cog):
                     check_msg = False
         return check_msg
 
-    async def send_selfintroduction(self, member) -> None:
+    async def send_selfintroduction(self, session, member) -> None:
         """
         DBに補完された自己紹介データをEmbedの形に入れ込み、自己紹介を送信する
 
@@ -234,12 +257,12 @@ class Self_Introduction(commands.Cog):
             message.authorから取得したメンバーオブジェクト
         """
         dm = await member.create_dm()
-        embed = self.add_embed(member)
+        embed = self.add_embed(session, member)
         # 完成した自己紹介文の最終チェック(修正が可能)
         embed_message = await dm.send(embed=embed)
         send_msg = "この内容で自己紹介を登録しますか？"\
-            + "OKなら👍リアクションを、修正する場合は♻️リアクションを押して下さい。"\
-            + "部分的に修正する場合は一度👍リアクションを押して投稿した後に修正可能になります"  # noqa: E501
+            + "\nOKなら👍リアクションを、修正する場合は♻️リアクションを押して下さい。"\
+            + "\n部分的に修正する場合は一度👍リアクションを押して投稿した後に修正可能になります"  # noqa: E501
         await dm.send(embed=self.strfembed(send_msg))
         # リアクションを追加
         await embed_message.add_reaction("👍")
@@ -249,19 +272,19 @@ class Self_Introduction(commands.Cog):
         # 押された絵文字が👍の時(今の内容で登録する)
         if emoji == "👍":
             after_msg = await self.INTRODUCTION_CHANNEL.send(embed=embed)
-            await after_msg.add_reaction("<:yoroshiku:761730298106478592>")
-            # DBの自己紹介メッセージIDを送信後のメッセージIDに変更
-            await self.db_update_selfintroduction(member, "sendmsg_id",
-                                                  after_msg.id, None)
+            # await after_msg.add_reaction("<:yoroshiku:761730298106478592>")
             send_msg2 = "登録が完了しました" \
-                + "※登録した自己紹介を修正したい場合は[ ¥predit ]のコマンド(7文字)を送信してください"   # noqa: E501
+                + "\n※登録した自己紹介を修正したい場合は[ ¥predit ]のコマンド(7文字)を送信してください"   # noqa: E501
             await dm.send(embed=self.strfembed(send_msg2))
             log_msg = f"[INFO] {member.name}の自己紹介が送信されました"
+            # 送信先のメッセージのIDをDBに保存
+            self.db_update_selfintroduction(session, member, "sendmsg_id",
+                                            after_msg.id, None)
             await self.LOG_CHANNEL.send(log_msg)
         elif emoji == "♻️":
-            await self.selfintroduction_reset(dm)
+            await self.selfintroduction_reset(session, member, dm)
 
-    async def selfintroduction_msg_update(self, member):
+    async def selfintroduction_msg_update(self, session, member):
         """
         既存の自己紹介メッセージが存在する場合は削除し、
         データ更新後の自己紹介メッセージを送信する
@@ -271,15 +294,16 @@ class Self_Introduction(commands.Cog):
         member : discord.Member
             message.authorから取得したメンバーオブジェクト
         """
-        member_data = self.db_select_selfintroduction(member)
+        member_data = self.db_select_selfintroduction(session, member)
         channel = self.INTRODUCTION_CHANNEL
-        msg_id = member_data["sendmsg_id"]
+        msg_id = member_data.sendmsg_id
         if msg_id:
-            # 既存の自己紹介メッセージを削除
-            selfintroduction_msg = await channel.fetch_message(msg_id)
-            await selfintroduction_msg.delete()
+            if msg_id.isdecimal():
+                # 既存の自己紹介メッセージを削除
+                selfintroduction_msg = await channel.fetch_message(int(msg_id))
+                await selfintroduction_msg.delete()
         # 完成した自己紹介を送信
-        await self.send_selfintroduction(member)
+        await self.send_selfintroduction(session, member)
 
     async def send_message(self, channel, dm, msgcontent, content):
         """
@@ -290,7 +314,7 @@ class Self_Introduction(commands.Cog):
         await dm.send(embed=self.strfembed(content))
 
     # 自己紹介を初期化する処理
-    async def selfintroduction_reset(self, dm) -> None:
+    async def selfintroduction_reset(self, session, member, dm) -> None:
         """
         DBの自己紹介データを初期化する処理
         ギルド・メンバーID、自己紹介が送信済みなら送信済みのカラムは変更しない
@@ -303,8 +327,7 @@ class Self_Introduction(commands.Cog):
         """
         await dm.send(embed=self.strfembed("内容を全てリセットします"))
         # TextChannelを再度作成し直し、リセットする
-        member = self.GUILD.get_member(dm.me.id)
-        self.db_reset_selfintroduction(member)
+        self.db_reset_selfintroduction(session, member)
         await dm.send(embed=self.strfembed(self.question1))
 
     def strfembed(self, str) -> discord.Embed:
@@ -326,7 +349,7 @@ class Self_Introduction(commands.Cog):
         return embed
 
     # 質問内容を追加する場合は、ここを弄る
-    def add_embed(self, member) -> discord.Embed:
+    def add_embed(self, session, member) -> discord.Embed:
         """
         自己紹介メッセージを作成するテンプレート
         DBから自己紹介データを取得し、
@@ -342,26 +365,28 @@ class Self_Introduction(commands.Cog):
         embed : discord.Embed
             自己紹介メッセージの完成版のembedオブジェクト
         """
-        obj = self.db_select_selfintroduction(member)
+        obj = self.db_select_selfintroduction(session, member)
+        desc_msg = f"name: {member.name}"\
+            + f"\njoined: {str(member.joined_at.strftime('%Y-%m-%d'))}"
         embed = discord.Embed(
             title="自己紹介",
-            description=f"name: {member.name}\njoined: {str(member.joined_at.strftime('%Y-%m-%d'))}",  # noqa: E501
-            color=self.gender_color(obj['sex']))
+            description=desc_msg,  # noqa: E501
+            color=self.gender_color(obj.sex))
         embed.set_thumbnail(url=member.avatar_url)
         embed.add_field(name="【 __呼び名__ 】",
-                        value=f":name_badge: {obj['nickname']}",
+                        value=f":name_badge: {obj.nickname}",
                         inline=False)
         embed.add_field(name="【 __TwitterID__ 】",
-                        value=f":globe_with_meridians: @{obj['twitter_id']}",
+                        value=f":globe_with_meridians: @{obj.twitter_id}",
                         inline=False)
         embed.add_field(name="【 __得意分野__ 】",
-                        value=f":ideograph_advantage: {obj['specialty']}",
+                        value=f":ideograph_advantage: {obj.specialty}",
                         inline=False)
         embed.add_field(name="【 __今まで勉強してきたこと__ 】",
-                        value=f":books: {obj['before_study']}",
+                        value=f":books: {obj.before_study}",
                         inline=False)
         embed.add_field(name="【 __これから勉強していきたいこと__ 】",
-                        value=f":pencil: {obj['after_study']}",
+                        value=f":pencil: {obj.after_study}",
                         inline=False)
         embed.set_footer(text=f"{member.id}")
         return embed
@@ -413,31 +438,31 @@ class Self_Introduction(commands.Cog):
         if reaction.emoji in emojis:
             return reaction.emoji
 
-    def current_setting(self, member, number):
-        obj = self.db_select_selfintroduction(member)
+    def current_setting(self, session, member, number):
+        obj = self.db_select_selfintroduction(session, member)
         desc = f"修正したい項目があればこのメッセージに付与されたリアクション（{number[0]}〜{number[-1]}）を押してください"  # noqa: E501
         embed = discord.Embed(
             title="現在自己紹介を修正",
             description=desc,
-            color=self.gender_color(obj['sex']))
+            color=self.gender_color(obj.sex))
         embed.add_field(name=f"{number[0]}",
-                        value=obj['nickname'], inline=False)
-        embed.add_field(name=f"{number[1]}", value=obj['sex'], inline=False)
+                        value=obj.nickname, inline=False)
+        embed.add_field(name=f"{number[1]}", value=obj.sex, inline=False)
         embed.add_field(name=f"{number[2]}",
-                        value=obj['twitter_id'], inline=False)
+                        value=obj.twitter_id, inline=False)
         embed.add_field(name=f"{number[3]}",
-                        value=obj['specialty'], inline=False)
+                        value=obj.specialty, inline=False)
         embed.add_field(name=f"{number[4]}",
-                        value=obj['before_study'], inline=False)
+                        value=obj.before_study, inline=False)
         embed.add_field(name=f"{number[5]}",
-                        value=obj['after_study'], inline=False)
+                        value=obj.after_study, inline=False)
         embed.add_field(
             name="♻️",
             value="初期化してもう一度初めから自己紹介を作成する場合",
             inline=False)
         return embed
 
-    def emoji_mod_column(self, member, emoji):
+    def emoji_mod_column(self, session, member, emoji):
         send_msg = f"[INFO] BOTのDMで{member.name}が{emoji}のリアクションを押下"
         print(send_msg)
         if emoji in self.emoji_number:
@@ -453,9 +478,10 @@ class Self_Introduction(commands.Cog):
                 select_column = "before_study"
             elif emoji == "6⃣":
                 select_column = "after_study"
-            self.db_update_selfintroduction("mod_column", select_column, None)
+            self.db_update_selfintroduction(session, member, "mod_column",
+                                            select_column, None)
         elif emoji == "♻️":
-            self.db_reset_selfintroduction(member)
+            self.db_reset_selfintroduction(session, member)
         else:
             # 想定する絵文字以外のリアクションが発生した場合
             log_msg = "[WARNING] 想定しないリアクションです"
@@ -473,35 +499,50 @@ class Self_Introduction(commands.Cog):
         if message.author.bot:
             return
         dm = await message.author.create_dm()
-        member = self.GUILD.get_member(dm.me.id)
+        member = self.GUILD.get_member(message.author.id)
         # 受信したメッセージの内容をどのカラムに保存するかを確認
         # 次不足しているデータの確認
+        session = Selfintroduction.session()
         missingdata_column, next_missingdata_column = self.check_missingdata(
-            member)
-        # データのチェック
-        check_msg = await self.check_msg_content(dm, missingdata_column,
-                                                 message.content)
-        if check_msg:
-            return
-        # 不足しているデータをDBに書き込み
-        self.db_update_selfintroduction(member, missingdata_column,
-                                        message.content,
-                                        next_missingdata_column)
-        # 不足しているデータから次の送信メッセージを選択
-        send_msg = self.select_nextquestionmsg(next_missingdata_column)
-        await dm.send(embed=self.strfembed(send_msg))
-        if not missingdata_column and not next_missingdata_column:
-            # データに不足がない場合
-            comp_msg = f"{message.author.name}さんの自己紹介文は既に登録済みです。"\
+            session, member)
+        if missingdata_column != "sendmsg_id":
+            # mod_columnが[sendmsg_id]以外の時
+            # データのチェック
+            check_msg = await self.check_msg_content(dm, missingdata_column,
+                                                     message.content)
+            if not check_msg:
+                # 想定しない文字列の場合は再度同じ質問を行い、return
+                send_msg = self.select_nextquestionmsg(missingdata_column)
+                await dm.send(embed=self.strfembed(send_msg))
+                return
+        if missingdata_column:
+            # 修正するカラムがある時
+            if "sendmsg_id" not in missingdata_column:
+                # 自己紹介が完成した時
+                self.db_update_selfintroduction(session, member,
+                                                missingdata_column,
+                                                message.content,
+                                                next_missingdata_column)
+                # 不足しているデータから次の送信メッセージを選択
+                send_msg = self.select_nextquestionmsg(next_missingdata_column)
+                await dm.send(embed=self.strfembed(send_msg))
+            if next_missingdata_column is None and "sendmsg_id" not in missingdata_column:  # noqa: E501
+                # ¥predit（自己紹介送信済）から一つのカラムを修正した時
+                await self.selfintroduction_msg_update(session, member)
+
+            if "sendmsg_id" in [missingdata_column, next_missingdata_column]:
+                # メッセージを勉強ギルドに送信する処理
+                await self.selfintroduction_msg_update(session, member)
+            session.commit()
+        else:
+            # 自己紹介が完成しており、変更カラムもなく送信済み
+            send_msg = f"{message.author.name}さんの自己紹介文は既に登録済みです。"\
                 + "\n変更する場合は、[ ¥predit ]とコマンドを送信して下さい。"
-            await message.channel.send(embed=self.strfembed(comp_msg))
+            await dm.send(embed=self.strfembed(send_msg))
             return
-        # メッセージを勉強ギルドに送信する処理
-        self.selfintroduction_msg_update(member)
-        # ここ続けて書く必要あり
 
     @commands.command()
-    @commands.dm_only()
+    # @commands.dm_only()
     async def predit(self, message):
         """
         既存の自己紹介データを送信し、修正するカラムをメンバーに指定してもらう
@@ -511,22 +552,19 @@ class Self_Introduction(commands.Cog):
         #     return
         member = self.GUILD.get_member(message.author.id)
         dm = await message.author.create_dm()
-        # if 自己紹介送信済みであること、mod_columnがNoneであること
-        #     send_msg = "自己紹介を登録してから[ ¥predit ]コマンド(7文字)を使用して下さい。" \
-        #         + "何かメッセージを送信してみてください"
-        #     await dm.send(embed=self.strfembed("send_msg"))
-        embed = self.current_setting(member, self.emoji_number)
+        session = Selfintroduction.session()
+        embed = self.current_setting(session, member, self.emoji_number)
         send_embedmsg = await dm.send(embed=embed)
         # メッセージにリアクションを付与
         for emoji in self.emoji_number:
             await send_embedmsg.add_reaction(emoji)
         await send_embedmsg.add_reaction("♻️")
-        emoji = await self.wait_reaction_add(message, self.emoji_number)
+        emoji = await self.wait_reaction_add(send_embedmsg, self.emoji_number)
         # 指定した修正するカラムをDBに保存
-        self.emoji_mod_column(member, emoji)
+        self.emoji_mod_column(session, member, emoji)
         # DBのmod_columnから次の質問する内容を選別し、DMで送信する
         missingdata_column, _ = self.check_missingdata(
-            member)
+            session, member)
         send_msg = self.select_nextquestionmsg(missingdata_column)
         await dm.send(embed=self.strfembed(send_msg))
 

--- a/Cogs/Managements/selfIntroduction.py
+++ b/Cogs/Managements/selfIntroduction.py
@@ -75,8 +75,9 @@ class Self_Introduction(commands.Cog):
         """
         # discord.DMChannelオブジェクトを取得
         dm = await member.create_dm()
+        session = Selfintroduction.session()
         # selfintroductionテーブルに参加したメンバーの情報をinsert
-        await self.db_insert_selfintroduction(member)
+        await self.db_insert_selfintroduction(session, member)
         # 参加者にdmを送る
         send_msg = "ギルドへの参加ありがとうございます"\
             + "\nこれから自己紹介の処理を進めますので、質問に答えて下さい"

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ chardet==3.0.4
 discord.py==1.7.3
 emojis==0.6.0
 idna==2.10
-mo9mo9db==0.0.20
+mo9mo9db==0.1.0
 multidict==4.7.6
 numpy==1.20.1
 pandas==1.2.3


### PR DESCRIPTION
- 自己紹介のデータをDiscordの専用ギルドのチャンネル管理からDBで管理するようにしました
- データをチャンネルに送信せず、DBに送信・取得・修正するコードに変更